### PR TITLE
Filerep end to end DROP CASCADE fixes

### DIFF
--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ck_sync1/expected/ck_sync1_co_compr_type_quicklz.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ck_sync1/expected/ck_sync1_co_compr_type_quicklz.ans
@@ -192,8 +192,9 @@ ALTER TYPE
  --Drop type
  
 Drop type if exists sync1_int_quicklz_2 cascade;
-psql:/path/sql_file:1: NOTICE:  drop cascades to function sync1_int_quicklz_2_out(sync1_int_quicklz_2)
-psql:/path/sql_file:1: NOTICE:  drop cascades to function sync1_int_quicklz_2_in(cstring)
+psql:/path/sql_file:1: NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to function sync1_int_quicklz_2_in(cstring)
+drop cascades to function sync1_int_quicklz_2_out(sync1_int_quicklz_2)
 DROP TYPE
  
 --ck_sync1
@@ -207,7 +208,8 @@ ALTER TYPE
  --Drop type
  
 Drop type if exists ck_sync1_int_quicklz_1 cascade;
-psql:/path/sql_file:1: NOTICE:  drop cascades to function ck_sync1_int_quicklz_1_out(ck_sync1_int_quicklz_1)
-psql:/path/sql_file:1: NOTICE:  drop cascades to function ck_sync1_int_quicklz_1_in(cstring)
+psql:/path/sql_file:1: NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to function ck_sync1_int_quicklz_1_in(cstring)
+drop cascades to function ck_sync1_int_quicklz_1_out(ck_sync1_int_quicklz_1)
 DROP TYPE
  

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ck_sync1/expected/ck_sync1_co_compr_type_rle_type.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ck_sync1/expected/ck_sync1_co_compr_type_rle_type.ans
@@ -192,8 +192,9 @@ ALTER TYPE
  --Drop type
  
 Drop type if exists sync1_int_rle_type_2 cascade;
-psql:/path/sql_file:1: NOTICE:  drop cascades to function sync1_int_rle_type_2_out(sync1_int_rle_type_2)
-psql:/path/sql_file:1: NOTICE:  drop cascades to function sync1_int_rle_type_2_in(cstring)
+psql:/path/sql_file:1: NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to function sync1_int_rle_type_2_in(cstring)
+drop cascades to function sync1_int_rle_type_2_out(sync1_int_rle_type_2)
 DROP TYPE
  
 --ck_sync1
@@ -207,7 +208,8 @@ ALTER TYPE
  --Drop type
  
 Drop type if exists ck_sync1_int_rle_type_1 cascade;
-psql:/path/sql_file:1: NOTICE:  drop cascades to function ck_sync1_int_rle_type_1_out(ck_sync1_int_rle_type_1)
-psql:/path/sql_file:1: NOTICE:  drop cascades to function ck_sync1_int_rle_type_1_in(cstring)
+psql:/path/sql_file:1: NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to function ck_sync1_int_rle_type_1_in(cstring)
+drop cascades to function ck_sync1_int_rle_type_1_out(ck_sync1_int_rle_type_1)
 DROP TYPE
  

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ck_sync1/expected/ck_sync1_co_compr_type_zlib.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ck_sync1/expected/ck_sync1_co_compr_type_zlib.ans
@@ -192,8 +192,9 @@ ALTER TYPE
  --Drop type
  
 Drop type if exists sync1_int_zlib_2 cascade;
-psql:/path/sql_file:1: NOTICE:  drop cascades to function sync1_int_zlib_2_out(sync1_int_zlib_2)
-psql:/path/sql_file:1: NOTICE:  drop cascades to function sync1_int_zlib_2_in(cstring)
+psql:/path/sql_file:1: NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to function sync1_int_zlib_2_in(cstring)
+drop cascades to function sync1_int_zlib_2_out(sync1_int_zlib_2)
 DROP TYPE
  
 --ck_sync1
@@ -207,7 +208,8 @@ ALTER TYPE
  --Drop type
  
 Drop type if exists ck_sync1_int_zlib_1 cascade;
-psql:/path/sql_file:1: NOTICE:  drop cascades to function ck_sync1_int_zlib_1_out(ck_sync1_int_zlib_1)
-psql:/path/sql_file:1: NOTICE:  drop cascades to function ck_sync1_int_zlib_1_in(cstring)
+psql:/path/sql_file:1: NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to function ck_sync1_int_zlib_1_in(cstring)
+drop cascades to function ck_sync1_int_zlib_1_out(ck_sync1_int_zlib_1)
 DROP TYPE
  

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ck_sync1/sql/init_file
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ck_sync1/sql/init_file
@@ -25,5 +25,6 @@
  m/position /
  m/failover requested /
  m/\'waiting for ack\'/
+ m/drop cascades to function/
 
 --end_matchignore

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ct/expected/ct_co_compr_type_quicklz.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ct/expected/ct_co_compr_type_quicklz.ans
@@ -138,8 +138,9 @@ ALTER TYPE
  --Drop type
  
 Drop type if exists sync1_int_quicklz_4 cascade;
-psql:/path/sql_file:1: NOTICE:  drop cascades to function sync1_int_quicklz_4_out(sync1_int_quicklz_4)
-psql:/path/sql_file:1: NOTICE:  drop cascades to function sync1_int_quicklz_4_in(cstring)
+psql:/path/sql_file:1: NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to function sync1_int_quicklz_4_out(sync1_int_quicklz_4)
+drop cascades to function sync1_int_quicklz_4_in(cstring)
 DROP TYPE
  
 --ck_sync1
@@ -153,8 +154,9 @@ ALTER TYPE
  --Drop type
  
 Drop type if exists ck_sync1_int_quicklz_3 cascade;
-psql:/path/sql_file:1: NOTICE:  drop cascades to function ck_sync1_int_quicklz_3_out(ck_sync1_int_quicklz_3)
-psql:/path/sql_file:1: NOTICE:  drop cascades to function ck_sync1_int_quicklz_3_in(cstring)
+psql:/path/sql_file:1: NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to function ck_sync1_int_quicklz_3_in(cstring)
+drop cascades to function ck_sync1_int_quicklz_3_out(ck_sync1_int_quicklz_3)
 DROP TYPE
 --ct
  
@@ -167,6 +169,7 @@ ALTER TYPE
  --Drop type
  
 Drop type if exists ct_int_quicklz_1 cascade; 
-psql:/path/sql_file:1: NOTICE:  drop cascades to function ct_int_quicklz_1_out(ct_int_quicklz_1)
-psql:/path/sql_file:1: NOTICE:  drop cascades to function ct_int_quicklz_1_in(cstring)
+psql:/path/sql_file:1: NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to function ct_int_quicklz_1_in(cstring)
+drop cascades to function ct_int_quicklz_1_out(ct_int_quicklz_1)
 DROP TYPE

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ct/expected/ct_co_compr_type_rle_type.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ct/expected/ct_co_compr_type_rle_type.ans
@@ -138,8 +138,9 @@ ALTER TYPE
  --Drop type
  
 Drop type if exists sync1_int_rle_type_4 cascade;
-psql:/path/sql_file:1: NOTICE:  drop cascades to function sync1_int_rle_type_4_out(sync1_int_rle_type_4)
-psql:/path/sql_file:1: NOTICE:  drop cascades to function sync1_int_rle_type_4_in(cstring)
+psql:/path/sql_file:1: NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to function sync1_int_rle_type_4_out(sync1_int_rle_type_4)
+drop cascades to function sync1_int_rle_type_4_in(cstring)
 DROP TYPE
  
 --ck_sync1
@@ -153,8 +154,9 @@ ALTER TYPE
  --Drop type
  
 Drop type if exists ck_sync1_int_rle_type_3 cascade;
-psql:/path/sql_file:1: NOTICE:  drop cascades to function ck_sync1_int_rle_type_3_out(ck_sync1_int_rle_type_3)
-psql:/path/sql_file:1: NOTICE:  drop cascades to function ck_sync1_int_rle_type_3_in(cstring)
+psql:/path/sql_file:1: NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to function ck_sync1_int_rle_type_3_in(cstring)
+drop cascades to function ck_sync1_int_rle_type_3_out(ck_sync1_int_rle_type_3)
 DROP TYPE
 --ct
  
@@ -167,6 +169,7 @@ ALTER TYPE
  --Drop type
  
 Drop type if exists ct_int_rle_type_1 cascade; 
-psql:/path/sql_file:1: NOTICE:  drop cascades to function ct_int_rle_type_1_out(ct_int_rle_type_1)
-psql:/path/sql_file:1: NOTICE:  drop cascades to function ct_int_rle_type_1_in(cstring)
+psql:/path/sql_file:1: NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to function ct_int_rle_type_1_in(cstring)
+drop cascades to function ct_int_rle_type_1_out(ct_int_rle_type_1)
 DROP TYPE

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ct/expected/ct_co_compr_type_zlib.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ct/expected/ct_co_compr_type_zlib.ans
@@ -138,8 +138,9 @@ ALTER TYPE
  --Drop type
  
 Drop type if exists sync1_int_zlib_4 cascade;
-psql:/path/sql_file:1: NOTICE:  drop cascades to function sync1_int_zlib_4_out(sync1_int_zlib_4)
-psql:/path/sql_file:1: NOTICE:  drop cascades to function sync1_int_zlib_4_in(cstring)
+psql:/path/sql_file:1: NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to function sync1_int_zlib_4_out(sync1_int_zlib_4)
+drop cascades to function sync1_int_zlib_4_in(cstring)
 DROP TYPE
  
 --ck_sync1
@@ -153,8 +154,9 @@ ALTER TYPE
  --Drop type
  
 Drop type if exists ck_sync1_int_zlib_3 cascade;
-psql:/path/sql_file:1: NOTICE:  drop cascades to function ck_sync1_int_zlib_3_out(ck_sync1_int_zlib_3)
-psql:/path/sql_file:1: NOTICE:  drop cascades to function ck_sync1_int_zlib_3_in(cstring)
+psql:/path/sql_file:1: NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to function ck_sync1_int_zlib_3_in(cstring)
+drop cascades to function ck_sync1_int_zlib_3_out(ck_sync1_int_zlib_3)
 DROP TYPE
 --ct
  
@@ -167,6 +169,7 @@ ALTER TYPE
  --Drop type
  
 Drop type if exists ct_int_zlib_1 cascade; 
-psql:/path/sql_file:1: NOTICE:  drop cascades to function ct_int_zlib_1_out(ct_int_zlib_1)
-psql:/path/sql_file:1: NOTICE:  drop cascades to function ct_int_zlib_1_in(cstring)
+psql:/path/sql_file:1: NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to function ct_int_zlib_1_in(cstring)
+drop cascades to function ct_int_zlib_1_out(ct_int_zlib_1)
 DROP TYPE

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ct/sql/init_file
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/ct/sql/init_file
@@ -25,5 +25,6 @@
  m/position /
  m/failover requested /
  m/\'waiting for ack\'/
+ m/drop cascades to function/
 
 --end_matchignore

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/resync/expected/resync_co_compr_type_quicklz.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/resync/expected/resync_co_compr_type_quicklz.ans
@@ -88,8 +88,9 @@ ALTER TYPE
  --Drop type
  
 Drop type if exists sync1_int_quicklz_6 cascade;
-psql:/path/sql_file:1: NOTICE:  drop cascades to function sync1_int_quicklz_6_out(sync1_int_quicklz_6)
-psql:/path/sql_file:1: NOTICE:  drop cascades to function sync1_int_quicklz_6_in(cstring)
+psql:/path/sql_file:1: NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to function sync1_int_quicklz_6_out(sync1_int_quicklz_6)
+drop cascades to function sync1_int_quicklz_6_in(cstring)
 DROP TYPE
  
 --ck_sync1
@@ -103,8 +104,9 @@ ALTER TYPE
  --Drop type
  
 Drop type if exists ck_sync1_int_quicklz_5 cascade;
-psql:/path/sql_file:1: NOTICE:  drop cascades to function ck_sync1_int_quicklz_5_out(ck_sync1_int_quicklz_5)
-psql:/path/sql_file:1: NOTICE:  drop cascades to function ck_sync1_int_quicklz_5_in(cstring)
+psql:/path/sql_file:1: NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to function ck_sync1_int_quicklz_5_in(cstring)
+drop cascades to function ck_sync1_int_quicklz_5_out(ck_sync1_int_quicklz_5)
 DROP TYPE
  
  
@@ -119,8 +121,9 @@ ALTER TYPE
  --Drop type
  
 Drop type if exists ct_int_quicklz_3 cascade; 
-psql:/path/sql_file:1: NOTICE:  drop cascades to function ct_int_quicklz_3_out(ct_int_quicklz_3)
-psql:/path/sql_file:1: NOTICE:  drop cascades to function ct_int_quicklz_3_in(cstring)
+psql:/path/sql_file:1: NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to function ct_int_quicklz_3_in(cstring)
+drop cascades to function ct_int_quicklz_3_out(ct_int_quicklz_3)
 DROP TYPE
  
 --resync
@@ -134,6 +137,7 @@ ALTER TYPE
  --Drop type
  
 Drop type if exists resync_int_quicklz_1 cascade; 
-psql:/path/sql_file:1: NOTICE:  drop cascades to function resync_int_quicklz_1_out(resync_int_quicklz_1)
-psql:/path/sql_file:1: NOTICE:  drop cascades to function resync_int_quicklz_1_in(cstring)
+psql:/path/sql_file:1: NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to function resync_int_quicklz_1_in(cstring)
+drop cascades to function resync_int_quicklz_1_out(resync_int_quicklz_1)
 DROP TYPE

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/resync/expected/resync_co_compr_type_rle_type.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/resync/expected/resync_co_compr_type_rle_type.ans
@@ -88,8 +88,9 @@ ALTER TYPE
  --Drop type
  
 Drop type if exists sync1_int_rle_type_6 cascade;
-psql:/path/sql_file:1: NOTICE:  drop cascades to function sync1_int_rle_type_6_out(sync1_int_rle_type_6)
-psql:/path/sql_file:1: NOTICE:  drop cascades to function sync1_int_rle_type_6_in(cstring)
+psql:/path/sql_file:1: NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to function sync1_int_rle_type_6_out(sync1_int_rle_type_6)
+drop cascades to function sync1_int_rle_type_6_in(cstring)
 DROP TYPE
  
 --ck_sync1
@@ -118,8 +119,9 @@ ALTER TYPE
  --Drop type
  
 Drop type if exists ct_int_rle_type_3 cascade; 
-psql:/path/sql_file:1: NOTICE:  drop cascades to function ct_int_rle_type_3_out(ct_int_rle_type_3)
-psql:/path/sql_file:1: NOTICE:  drop cascades to function ct_int_rle_type_3_in(cstring)
+psql:/path/sql_file:1: NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to function ck_sync1_int_rle_type_5_in(cstring)
+drop cascades to function ck_sync1_int_rle_type_5_out(ck_sync1_int_rle_type_5)
 DROP TYPE
  
 --resync
@@ -133,6 +135,7 @@ ALTER TYPE
  --Drop type
  
 Drop type if exists resync_int_rle_type_1 cascade; 
-psql:/path/sql_file:1: NOTICE:  drop cascades to function resync_int_rle_type_1_out(resync_int_rle_type_1)
-psql:/path/sql_file:1: NOTICE:  drop cascades to function resync_int_rle_type_1_in(cstring)
+psql:/path/sql_file:1: NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to function ct_int_rle_type_3_in(cstring)
+drop cascades to function ct_int_rle_type_3_out(ct_int_rle_type_3)
 DROP TYPE

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/resync/expected/resync_co_compr_type_zlib.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/resync/expected/resync_co_compr_type_zlib.ans
@@ -88,8 +88,9 @@ ALTER TYPE
  --Drop type
  
 Drop type if exists sync1_int_zlib_6 cascade;
-psql:/path/sql_file:1: NOTICE:  drop cascades to function sync1_int_zlib_6_out(sync1_int_zlib_6)
-psql:/path/sql_file:1: NOTICE:  drop cascades to function sync1_int_zlib_6_in(cstring)
+psql:/path/sql_file:1: NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to function sync1_int_zlib_6_out(sync1_int_zlib_6)
+drop cascades to function sync1_int_zlib_6_in(cstring)
 DROP TYPE
  
 --ck_sync1
@@ -103,8 +104,9 @@ ALTER TYPE
  --Drop type
  
 Drop type if exists ck_sync1_int_zlib_5 cascade;
-psql:/path/sql_file:1: NOTICE:  drop cascades to function ck_sync1_int_zlib_5_out(ck_sync1_int_zlib_5)
-psql:/path/sql_file:1: NOTICE:  drop cascades to function ck_sync1_int_zlib_5_in(cstring)
+psql:/path/sql_file:1: NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to function ck_sync1_int_zlib_5_out(ck_sync1_int_zlib_5)
+drop cascades to function ck_sync1_int_zlib_5_in(cstring)
 DROP TYPE
  
 --ct
@@ -118,8 +120,9 @@ ALTER TYPE
  --Drop type
  
 Drop type if exists ct_int_zlib_3 cascade; 
-psql:/path/sql_file:1: NOTICE:  drop cascades to function ct_int_zlib_3_out(ct_int_zlib_3)
-psql:/path/sql_file:1: NOTICE:  drop cascades to function ct_int_zlib_3_in(cstring)
+psql:/path/sql_file:1: NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to function ct_int_zlib_3_in(cstring)
+drop cascades to function ct_int_zlib_3_out(ct_int_zlib_3)
 DROP TYPE
  
 --resync
@@ -133,6 +136,7 @@ ALTER TYPE
  --Drop type
  
 Drop type if exists resync_int_zlib_1 cascade; 
-psql:/path/sql_file:1: NOTICE:  drop cascades to function resync_int_zlib_1_out(resync_int_zlib_1)
-psql:/path/sql_file:1: NOTICE:  drop cascades to function resync_int_zlib_1_in(cstring)
+psql:/path/sql_file:1: NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to function resync_int_zlib_1_in(cstring)
+drop cascades to function resync_int_zlib_1_out(resync_int_zlib_1)
 DROP TYPE

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/resync/sql/init_file
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/resync/sql/init_file
@@ -25,5 +25,6 @@
  m/position /
  m/failover requested /
  m/\'waiting for ack\'/
+ m/drop cascades to function/
 
 --end_matchignore

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync1/expected/sync1_co_compr_type_quicklz.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync1/expected/sync1_co_compr_type_quicklz.ans
@@ -218,7 +218,8 @@ ALTER TYPE
  --Drop type
  
 Drop type if exists sync1_int_quicklz_1 cascade;
-psql:/path/sql_file:1: NOTICE:  drop cascades to function sync1_int_quicklz_1_out(sync1_int_quicklz_1)
-psql:/path/sql_file:1: NOTICE:  drop cascades to function sync1_int_quicklz_1_in(cstring)
+psql:/path/sql_file:1: NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to function sync1_int_quicklz_1_in(cstring)
+drop cascades to function sync1_int_quicklz_1_out(sync1_int_quicklz_1)
 DROP TYPE
  

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync1/expected/sync1_co_compr_type_rle_type.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync1/expected/sync1_co_compr_type_rle_type.ans
@@ -218,7 +218,8 @@ ALTER TYPE
  --Drop type
  
 Drop type if exists sync1_int_rle_type_1 cascade;
-psql:/path/sql_file:1: NOTICE:  drop cascades to function sync1_int_rle_type_1_out(sync1_int_rle_type_1)
-psql:/path/sql_file:1: NOTICE:  drop cascades to function sync1_int_rle_type_1_in(cstring)
+psql:/path/sql_file:1: NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to function sync1_int_rle_type_1_in(cstring)
+drop cascades to function sync1_int_rle_type_1_out(sync1_int_rle_type_1)
 DROP TYPE
  

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync1/expected/sync1_co_compr_type_zlib.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync1/expected/sync1_co_compr_type_zlib.ans
@@ -218,7 +218,8 @@ ALTER TYPE
  --Drop type
  
 Drop type if exists sync1_int_zlib_1 cascade;
-psql:/path/sql_file:1: NOTICE:  drop cascades to function sync1_int_zlib_1_out(sync1_int_zlib_1)
-psql:/path/sql_file:1: NOTICE:  drop cascades to function sync1_int_zlib_1_in(cstring)
+psql:/path/sql_file:1: NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to function sync1_int_zlib_1_in(cstring)
+drop cascades to function sync1_int_zlib_1_out(sync1_int_zlib_1)
 DROP TYPE
  

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync1/sql/init_file
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync1/sql/init_file
@@ -25,5 +25,6 @@
  m/position /
  m/failover requested /
  m/\'waiting for ack\'/
+ m/drop cascades to function/
 
 --end_matchignore

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync2/expected/sync2_co_compr_type_quicklz.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync2/expected/sync2_co_compr_type_quicklz.ans
@@ -62,8 +62,9 @@ ALTER TYPE
  --Drop type
  
 Drop type if exists sync1_int_quicklz_7 cascade;
-psql:/path/sql_file:1: NOTICE:  drop cascades to function sync1_int_quicklz_7_in(cstring)
-psql:/path/sql_file:1: NOTICE:  drop cascades to function sync1_int_quicklz_7_out(sync1_int_quicklz_7)
+psql:/path/sql_file:1: NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to function sync1_int_quicklz_7_in(cstring)
+drop cascades to function sync1_int_quicklz_7_out(sync1_int_quicklz_7)
 DROP TYPE
  
 --ck_sync1
@@ -77,8 +78,9 @@ ALTER TYPE
  --Drop type
  
 Drop type if exists ck_sync1_int_quicklz_6 cascade;
-psql:/path/sql_file:1: NOTICE:  drop cascades to function ck_sync1_int_quicklz_6_out(ck_sync1_int_quicklz_6)
-psql:/path/sql_file:1: NOTICE:  drop cascades to function ck_sync1_int_quicklz_6_in(cstring)
+psql:/path/sql_file:1: NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to function ck_sync1_int_quicklz_6_in(cstring)
+drop cascades to function ck_sync1_int_quicklz_6_out(ck_sync1_int_quicklz_6)
 DROP TYPE
 --ct
  
@@ -91,8 +93,9 @@ ALTER TYPE
  --Drop type
  
 Drop type if exists ct_int_quicklz_4 cascade; 
-psql:/path/sql_file:1: NOTICE:  drop cascades to function ct_int_quicklz_4_out(ct_int_quicklz_4)
-psql:/path/sql_file:1: NOTICE:  drop cascades to function ct_int_quicklz_4_in(cstring)
+psql:/path/sql_file:1: NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to function ct_int_quicklz_4_in(cstring)
+drop cascades to function ct_int_quicklz_4_out(ct_int_quicklz_4)
 DROP TYPE
  
 --resync
@@ -106,8 +109,9 @@ ALTER TYPE
  --Drop type
  
 Drop type if exists resync_int_quicklz_2 cascade; 
-psql:/path/sql_file:1: NOTICE:  drop cascades to function resync_int_quicklz_2_out(resync_int_quicklz_2)
-psql:/path/sql_file:1: NOTICE:  drop cascades to function resync_int_quicklz_2_in(cstring)
+psql:/path/sql_file:1: NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to function resync_int_quicklz_2_out(resync_int_quicklz_2)
+drop cascades to function resync_int_quicklz_2_in(cstring)
 DROP TYPE
 --sync2
  
@@ -120,6 +124,7 @@ ALTER TYPE
  --Drop type
  
 Drop type if exists sync2_int_quicklz_1 cascade; 
-psql:/path/sql_file:1: NOTICE:  drop cascades to function sync2_int_quicklz_1_out(sync2_int_quicklz_1)
-psql:/path/sql_file:1: NOTICE:  drop cascades to function sync2_int_quicklz_1_in(cstring)
+psql:/path/sql_file:1: NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to function sync2_int_quicklz_1_in(cstring)
+drop cascades to function sync2_int_quicklz_1_out(sync2_int_quicklz_1)
 DROP TYPE

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync2/expected/sync2_co_compr_type_rle_type.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync2/expected/sync2_co_compr_type_rle_type.ans
@@ -62,8 +62,9 @@ ALTER TYPE
  --Drop type
  
 Drop type if exists sync1_int_rle_type_7 cascade;
-psql:/path/sql_file:1: NOTICE:  drop cascades to function sync1_int_rle_type_7_in(cstring)
-psql:/path/sql_file:1: NOTICE:  drop cascades to function sync1_int_rle_type_7_out(sync1_int_rle_type_7)
+psql:/path/sql_file:1: NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to function sync1_int_rle_type_7_in(cstring)
+drop cascades to function sync1_int_rle_type_7_out(sync1_int_rle_type_7)
 DROP TYPE
  
 --ck_sync1
@@ -77,8 +78,9 @@ ALTER TYPE
  --Drop type
  
 Drop type if exists ck_sync1_int_rle_type_6 cascade;
-psql:/path/sql_file:1: NOTICE:  drop cascades to function ck_sync1_int_rle_type_6_in(cstring)
-psql:/path/sql_file:1: NOTICE:  drop cascades to function ck_sync1_int_rle_type_6_out(ck_sync1_int_rle_type_6)
+psql:/path/sql_file:1: NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to function ck_sync1_int_rle_type_6_in(cstring)
+drop cascades to function ck_sync1_int_rle_type_6_out(ck_sync1_int_rle_type_6)
 DROP TYPE
 --ct
  
@@ -91,8 +93,9 @@ ALTER TYPE
  --Drop type
  
 Drop type if exists ct_int_rle_type_4 cascade; 
-psql:/path/sql_file:1: NOTICE:  drop cascades to function ct_int_rle_type_4_out(ct_int_rle_type_4)
-psql:/path/sql_file:1: NOTICE:  drop cascades to function ct_int_rle_type_4_in(cstring)
+psql:/path/sql_file:1: NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to function ct_int_rle_type_4_in(cstring)
+drop cascades to function ct_int_rle_type_4_out(ct_int_rle_type_4)
 DROP TYPE
  
 --resync
@@ -106,8 +109,9 @@ ALTER TYPE
  --Drop type
  
 Drop type if exists resync_int_rle_type_2 cascade; 
-psql:/path/sql_file:1: NOTICE:  drop cascades to function resync_int_rle_type_2_out(resync_int_rle_type_2)
-psql:/path/sql_file:1: NOTICE:  drop cascades to function resync_int_rle_type_2_in(cstring)
+psql:/path/sql_file:1: NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to function resync_int_rle_type_2_in(cstring)
+drop cascades to function resync_int_rle_type_2_out(resync_int_rle_type_2)
 DROP TYPE
 --sync2
  
@@ -120,6 +124,7 @@ ALTER TYPE
  --Drop type
  
 Drop type if exists sync2_int_rle_type_1 cascade; 
-psql:/path/sql_file:1: NOTICE:  drop cascades to function sync2_int_rle_type_1_out(sync2_int_rle_type_1)
-psql:/path/sql_file:1: NOTICE:  drop cascades to function sync2_int_rle_type_1_in(cstring)
+psql:/path/sql_file:1: NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to function sync2_int_rle_type_1_in(cstring)
+drop cascades to function sync2_int_rle_type_1_out(sync2_int_rle_type_1)
 DROP TYPE

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync2/expected/sync2_co_compr_type_zlib.ans
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync2/expected/sync2_co_compr_type_zlib.ans
@@ -62,8 +62,9 @@ ALTER TYPE
  --Drop type
  
 Drop type if exists sync1_int_zlib_7 cascade;
-psql:/path/sql_file:1: NOTICE:  drop cascades to function sync1_int_zlib_7_in(cstring)
-psql:/path/sql_file:1: NOTICE:  drop cascades to function sync1_int_zlib_7_out(sync1_int_zlib_7)
+psql:/path/sql_file:1: NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to function sync1_int_zlib_7_in(cstring)
+drop cascades to function sync1_int_zlib_7_out(sync1_int_zlib_7)
 DROP TYPE
  
 --ck_sync1
@@ -77,8 +78,9 @@ ALTER TYPE
  --Drop type
  
 Drop type if exists ck_sync1_int_zlib_6 cascade;
-psql:/path/sql_file:1: NOTICE:  drop cascades to function ck_sync1_int_zlib_6_in(cstring)
-psql:/path/sql_file:1: NOTICE:  drop cascades to function ck_sync1_int_zlib_6_out(ck_sync1_int_zlib_6)
+psql:/path/sql_file:1: NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to function ck_sync1_int_zlib_6_in(cstring)
+drop cascades to function ck_sync1_int_zlib_6_out(ck_sync1_int_zlib_6)
 DROP TYPE
 --ct
  
@@ -91,8 +93,9 @@ ALTER TYPE
  --Drop type
  
 Drop type if exists ct_int_zlib_4 cascade; 
-psql:/path/sql_file:1: NOTICE:  drop cascades to function ct_int_zlib_4_out(ct_int_zlib_4)
-psql:/path/sql_file:1: NOTICE:  drop cascades to function ct_int_zlib_4_in(cstring)
+psql:/path/sql_file:1: NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to function ct_int_zlib_4_in(cstring)
+drop cascades to function ct_int_zlib_4_out(ct_int_zlib_4)
 DROP TYPE
  
 --resync
@@ -106,8 +109,9 @@ ALTER TYPE
  --Drop type
  
 Drop type if exists resync_int_zlib_2 cascade; 
-psql:/path/sql_file:1: NOTICE:  drop cascades to function resync_int_zlib_2_out(resync_int_zlib_2)
-psql:/path/sql_file:1: NOTICE:  drop cascades to function resync_int_zlib_2_in(cstring)
+psql:/path/sql_file:1: NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to function resync_int_zlib_2_in(cstring)
+drop cascades to function resync_int_zlib_2_out(resync_int_zlib_2)
 DROP TYPE
 --sync2
  
@@ -120,6 +124,7 @@ ALTER TYPE
  --Drop type
  
 Drop type if exists sync2_int_zlib_1 cascade; 
-psql:/path/sql_file:1: NOTICE:  drop cascades to function sync2_int_zlib_1_out(sync2_int_zlib_1)
-psql:/path/sql_file:1: NOTICE:  drop cascades to function sync2_int_zlib_1_in(cstring)
+psql:/path/sql_file:1: NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to function sync2_int_zlib_1_in(cstring)
+drop cascades to function sync2_int_zlib_1_out(sync2_int_zlib_1)
 DROP TYPE

--- a/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync2/sql/init_file
+++ b/src/test/tinc/tincrepo/mpp/gpdb/tests/storage/filerep_end_to_end/sync2/sql/init_file
@@ -25,5 +25,6 @@
  m/position /
  m/failover requested /
  m/\'waiting for ack\'/
+ m/drop cascades to function/
 
 --end_matchignore


### PR DESCRIPTION
The merges from upstream changed the DROP <object> CASCADE NOTICE and DETAIL messages,
breaking the filerep end to end TINC tests. This change ignores the cascade messages.

Because the cascade NOTICE messages are now in a non-deterministic order, we ignore them
entirely, and instead rely on gpcheckcat to determine if all dependencies have been
successfully dropped.

Signed-off-by: Tom Meyer <tmeyer@pivotal.io>