### PR TITLE
 WIP: try to recreate the 'materialize slot' logic for heap inserts

### DIFF
--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -3170,6 +3170,7 @@ ExecInsert(TupleTableSlot *slot,
 	partslot = reconstructMatchingTupleSlot(slot, resultRelInfo);
 	if (rel_is_heap)
 	{
+		/* GPDB_84_MERGE_FIXME: do we need a similar function for memtuples? */
 		tuple = ExecMaterializeSlotHeapTuple(partslot);
 	}
 	else if (rel_is_aorows)

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -3170,7 +3170,7 @@ ExecInsert(TupleTableSlot *slot,
 	partslot = reconstructMatchingTupleSlot(slot, resultRelInfo);
 	if (rel_is_heap)
 	{
-		tuple = ExecCopySlotHeapTuple(partslot);
+		tuple = ExecMaterializeSlotHeapTuple(partslot);
 	}
 	else if (rel_is_aorows)
 	{

--- a/src/backend/executor/execTuples.c
+++ b/src/backend/executor/execTuples.c
@@ -765,6 +765,10 @@ ExecMaterializeSlotHeapTuple(TupleTableSlot *slot)
 	/*
 	 * If we have a regular physical tuple, and it's locally palloc'd, we have
 	 * nothing to do.
+	 *
+	 * GPDB_84_MERGE_FIXME: do we need to utilize the "shouldFree" logic that's
+	 * set up elsewhere? We would need to update this function and others to set
+	 * the SHOULDFREE flag when appropriate.
 	 */
 	if (slot->PRIVATE_tts_heaptuple && slot->PRIVATE_tts_htup_buf)
 		return slot->PRIVATE_tts_heaptuple;

--- a/src/include/executor/tuptable.h
+++ b/src/include/executor/tuptable.h
@@ -398,6 +398,7 @@ extern MemTuple ExecCopySlotMemTuple(TupleTableSlot *slot);
 extern MemTuple ExecCopySlotMemTupleTo(TupleTableSlot *slot, MemoryContext pctxt, char *dest, unsigned int *len);
 
 extern HeapTuple ExecFetchSlotHeapTuple(TupleTableSlot *slot);
+extern HeapTuple ExecMaterializeSlotHeapTuple(TupleTableSlot *slot);
 extern MemTuple ExecFetchSlotMemTuple(TupleTableSlot *slot, bool inline_toast);
 
 extern Datum ExecFetchSlotTupleDatum(TupleTableSlot *slot);


### PR DESCRIPTION
This patch tries to recreate a GPDB-specific version of upstream's ExecMaterializeSlot, which guarantees local storage of the materialized heaptuple. It does not try to touch memtuples (which may need their own version of materialization).

This is an alternative approach to #3, which tries to match upstream's strategy. It seems to fix the memory-accounting test failure and the gpcheckcat failure on my machine (though with my recent break to the merge-CI ICW, I am not feeling super confident). Please poke holes!