### PR TITLE
Addressing 8.4 merge snapshot fixes

### DIFF
--- a/src/backend/utils/time/snapmgr.c
+++ b/src/backend/utils/time/snapmgr.c
@@ -167,28 +167,24 @@ GetTransactionSnapshot(void)
 
 	if (IsXactIsoLevelSerializable)
 	{
-		/*
-		 * GPDB_84_MERGE_FIXME
-		elog((Debug_print_snapshot_dtm ? LOG : DEBUG5),"[Distributed Snapshot #%u] *Serializable Skip* (gxid = %u, '%s')",
-			 (SerializableSnapshot == NULL ? 0 : SerializableSnapshot->distribSnapshotWithLocalMapping.ds.distribSnapshotId),
+		elog((Debug_print_snapshot_dtm ? LOG : DEBUG5),
+			 "[Distributed Snapshot #%u] *Serializable* (gxid = %u, '%s')",
+			 CurrentSnapshot->distribSnapshotWithLocalMapping.ds.distribSnapshotId,
 			 getDistributedTransactionId(),
 			 DtxContextToString(DistributedTransactionContext));
-		 */
 
 		UpdateSerializableCommandId(CurrentSnapshot->curcid);
 
 		return CurrentSnapshot;
 	}
 
-	/*
-	 * GPDB_84_MERGE_FIXME
-	elog((Debug_print_snapshot_dtm ? LOG : DEBUG5),"[Distributed Snapshot #%u] (gxid = %u, '%s')",
-		 (LatestSnapshot == NULL ? 0 : LatestSnapshot->distribSnapshotWithLocalMapping.ds.distribSnapshotId),
+	CurrentSnapshot = GetSnapshotData(&CurrentSnapshotData);
+
+	elog((Debug_print_snapshot_dtm ? LOG : DEBUG5),
+		 "[Distributed Snapshot #%u] (gxid = %u, '%s')",
+		 CurrentSnapshot->distribSnapshotWithLocalMapping.ds.distribSnapshotId,
 		 getDistributedTransactionId(),
 		 DtxContextToString(DistributedTransactionContext));
-	 */
-
-	CurrentSnapshot = GetSnapshotData(&CurrentSnapshotData);
 
 	return CurrentSnapshot;
 }
@@ -719,4 +715,17 @@ AtEOXact_Snapshot(bool isCommit)
 
 	FirstSnapshotSet = false;
 	registered_serializable = false;
+}
+
+DistributedSnapshotWithLocalMapping*
+GetCurrentDistributedSnapshotWithLocalMapping()
+{
+	if (!FirstSnapshotSet)
+		return NULL;
+
+	Assert(CurrentSnapshot);
+	if (CurrentSnapshot->haveDistribSnapshot)
+		return &CurrentSnapshot->distribSnapshotWithLocalMapping;
+
+	return NULL;
 }

--- a/src/include/utils/snapmgr.h
+++ b/src/include/utils/snapmgr.h
@@ -40,5 +40,6 @@ extern void AtSubAbort_Snapshot(int level);
 extern void AtEOXact_Snapshot(bool isCommit);
 
 extern void LogDistributedSnapshotInfo(Snapshot snapshot, const char *prefix);
+extern DistributedSnapshotWithLocalMapping* GetCurrentDistributedSnapshotWithLocalMapping(void);
 
 #endif /* SNAPMGR_H */


### PR DESCRIPTION
d6f599dfb611fd76ec6cfd7a41663a6c6273830f left some FIXME's and also modified few places for snapshot. Addressing some of the code which should be modified to avoid calling `GetLastesSnapshot()` as its heavy since acquires new snapshot every time, so its usage should be minimal.