### PR TITLE
(WIP) Use ExecMaterializeSlotHeapTuple to make writable copy so that we are safe to modify HeapTuple in place.

### DIFF
--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -155,13 +155,13 @@ void ExecCheckRTPerms(List *rangeTable);
 void ExecCheckRTEPerms(RangeTblEntry *rte);
 
 /*
- * For a partitioned insert target only:  
+ * For a partitioned insert target only:
  * This type represents an entry in the per-part hash table stored at
- * estate->es_partition_state->result_partition_hash.   The table maps 
+ * estate->es_partition_state->result_partition_hash.   The table maps
  * part OID -> ResultRelInfo and avoids repeated calculation of the
  * result information.
  */
-typedef struct ResultPartHashEntry 
+typedef struct ResultPartHashEntry
 {
 	Oid targetid; /* OID of part relation */
 	int offset; /* Index ResultRelInfo in es_result_partitions */
@@ -1117,14 +1117,14 @@ ExecutorEnd(QueryDesc *queryDesc)
 	 * Release EState and per-query memory context
 	 */
 	FreeExecutorState(estate);
-	
+
 	/**
 	 * Perfmon related stuff.
 	 */
-	if (gp_enable_gpperfmon 
+	if (gp_enable_gpperfmon
 			&& Gp_role == GP_ROLE_DISPATCH
 			&& queryDesc->gpmon_pkt)
-	{			
+	{
 		gpmon_qlog_query_end(queryDesc->gpmon_pkt);
 		queryDesc->gpmon_pkt = NULL;
 	}
@@ -1355,7 +1355,7 @@ static PartitionNode *
 BuildPartitionNodeFromRoot(Oid relid)
 {
 	PartitionNode *partitionNode = NULL;
-	
+
 	if (rel_is_child_partition(relid))
 	{
 		relid = rel_partition_get_master(relid);
@@ -1396,7 +1396,7 @@ createPartitionState(PartitionNode *partsAndRules,
 					 int resultPartSize)
 {
 	Assert(partsAndRules != NULL);
-	
+
 	PartitionState *partitionState = makeNode(PartitionState);
 	partitionState->accessMethods = createPartitionAccessMethods(num_partition_levels(partsAndRules));
 	partitionState->max_partition_attr = max_partition_attr(partsAndRules);
@@ -1444,7 +1444,7 @@ InitializeResultRelations(PlannedStmt *plannedstmt, EState *estate, CmdType oper
 	 */
 	/* CDB: we must promote locks for UPDATE and DELETE operations. */
 	lockmode = (Gp_role != GP_ROLE_EXECUTE || Gp_is_writer) ? RowExclusiveLock : NoLock;
-	
+
 	Assert(plannedstmt != NULL && estate != NULL);
 
 	if (plannedstmt->resultRelations)
@@ -1475,7 +1475,7 @@ InitializeResultRelations(PlannedStmt *plannedstmt, EState *estate, CmdType oper
 							  resultRelationIndex,
 							  operation,
 							  estate->es_instrument);
-			
+
 			resultRelInfo++;
 		}
 		estate->es_result_relations = resultRelInfos;
@@ -1503,7 +1503,7 @@ InitializeResultRelations(PlannedStmt *plannedstmt, EState *estate, CmdType oper
 	 * we do this information exchange here, via the parseTree. For now
 	 * this is used for partitioned and append-only tables.
 	 */
-	
+
 	if (Gp_role == GP_ROLE_EXECUTE)
 	{
 		estate->es_result_partitions = plannedstmt->result_partitions;
@@ -1520,15 +1520,15 @@ InitializeResultRelations(PlannedStmt *plannedstmt, EState *estate, CmdType oper
 		}
 
 		estate->es_result_partitions = BuildPartitionNodeFromRoot(relid);
-		
+
 		/*
 		 * list all the relids that may take part in this insert operation
 		 */
 		all_relids = lappend_oid(all_relids, relid);
 		all_relids = list_concat(all_relids,
 								 all_partition_relids(estate->es_result_partitions));
-		
-        /* 
+
+        /*
          * We also assign a segno for a deletion operation.
          * That segno will later be touched to ensure a correct
          * incremental backup.
@@ -1537,7 +1537,7 @@ InitializeResultRelations(PlannedStmt *plannedstmt, EState *estate, CmdType oper
 
 		plannedstmt->result_partitions = estate->es_result_partitions;
 		plannedstmt->result_aosegnos = estate->es_result_aosegnos;
-		
+
 		/* Set any QD resultrels segno, just in case. The QEs set their own in ExecInsert(). */
         int relno = 0;
         ResultRelInfo* relinfo;
@@ -1547,7 +1547,7 @@ InitializeResultRelations(PlannedStmt *plannedstmt, EState *estate, CmdType oper
             ResultRelInfoSetSegno(relinfo, estate->es_result_aosegnos);
         }
 	}
-	
+
 	estate->es_partition_state = NULL;
 	if (estate->es_result_partitions)
 	{
@@ -1564,7 +1564,7 @@ static void
 InitializeQueryPartsMetadata(PlannedStmt *plannedstmt, EState *estate)
 {
 	Assert(plannedstmt != NULL && estate != NULL);
-	
+
 	if (plannedstmt->queryPartOids == NIL)
 	{
 		plannedstmt->queryPartsMetadata = NIL;
@@ -1588,17 +1588,17 @@ InitializeQueryPartsMetadata(PlannedStmt *plannedstmt, EState *estate)
 				lappend(plannedstmt->queryPartsMetadata, partitionNode);
 		}
 	}
-	
+
 	/* Populate the partitioning metadata to EState */
 	Assert(estate->dynamicTableScanInfo != NULL);
-	
+
 	MemoryContext oldContext = MemoryContextSwitchTo(estate->es_query_cxt);
-	
+
 	ListCell *lc = NULL;
 	foreach(lc, plannedstmt->queryPartsMetadata)
 	{
 		PartitionNode *partsAndRules = (PartitionNode *)lfirst(lc);
-		
+
 		PartitionMetadata *metadata = palloc(sizeof(PartitionMetadata));
 		metadata->partsAndRules = partsAndRules;
 		Assert(metadata->partsAndRules != NULL);
@@ -1606,7 +1606,7 @@ InitializeQueryPartsMetadata(PlannedStmt *plannedstmt, EState *estate)
 		estate->dynamicTableScanInfo->partsMetadata =
 			lappend(estate->dynamicTableScanInfo->partsMetadata, metadata);
 	}
-	
+
 	MemoryContextSwitchTo(oldContext);
 }
 
@@ -1912,7 +1912,7 @@ InitPlan(QueryDesc *queryDesc, int eflags)
 
 	if (RootSliceIndex(estate) != LocallyExecutingSliceIndex(estate))
 		return;
-	
+
 	/*
 	 * Get the tuple descriptor describing the type of tuples to return. (this
 	 * is especially important if we are creating a relation with "SELECT
@@ -2627,7 +2627,7 @@ ExecEndPlan(PlanState *planstate, EState *estate)
 			}
 			resultRelInfo->ri_updateDesc = NULL;
 		}
-		
+
 		if (resultRelInfo->ri_resultSlot)
 		{
 			Assert(resultRelInfo->ri_resultSlot->tts_tupleDescriptor);
@@ -3082,7 +3082,7 @@ ExecSelect(TupleTableSlot *slot,
  *		the base relation and insert appropriate tuples into the
  *		index relations.
  *		Insert can be part of an update operation when
- *		there is a preceding SplitUpdate node. 
+ *		there is a preceding SplitUpdate node.
  * ----------------------------------------------------------------
  */
 void
@@ -3255,7 +3255,7 @@ ExecInsert(TupleTableSlot *slot,
 		if (resultRelInfo->ri_aocsInsertDesc == NULL)
 		{
 			ResultRelInfoSetSegno(resultRelInfo, estate->es_result_aosegnos);
-			resultRelInfo->ri_aocsInsertDesc = aocs_insert_init(resultRelationDesc, 
+			resultRelInfo->ri_aocsInsertDesc = aocs_insert_init(resultRelationDesc,
 																resultRelInfo->ri_aosegno, false);
 		}
 
@@ -3321,7 +3321,7 @@ ExecInsert(TupleTableSlot *slot,
  *		DELETE is like UPDATE, except that we delete the tuple and no
  *		index modifications are needed.
  *		DELETE can be part of an update operation when
- *		there is a preceding SplitUpdate node. 
+ *		there is a preceding SplitUpdate node.
  *
  * ----------------------------------------------------------------
  */
@@ -3388,12 +3388,12 @@ ExecDelete(ItemPointer tupleid,
 	bool isAOColsTable = RelationIsAoCols(resultRelationDesc);
 	bool isExternalTable = RelationIsExternal(resultRelationDesc);
 
-	if (isExternalTable && estate->es_result_partitions && 
+	if (isExternalTable && estate->es_result_partitions &&
 		estate->es_result_partitions->part->parrelid != 0)
 	{
 		ereport(ERROR,
 			(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-			errmsg("Delete from external partitions not supported.")));			
+			errmsg("Delete from external partitions not supported.")));
 		return;
 	}
 	/*
@@ -3420,22 +3420,22 @@ ldelete:;
 			if (!isUpdate)
 				ereport(ERROR,
 					   (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-						errmsg("Deletes on append-only tables are not supported in serializable transactions.")));		
+						errmsg("Deletes on append-only tables are not supported in serializable transactions.")));
 			else
 				ereport(ERROR,
 					   (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-						errmsg("Updates on append-only tables are not supported in serializable transactions.")));	
+						errmsg("Updates on append-only tables are not supported in serializable transactions.")));
 		}
 
 		if (resultRelInfo->ri_deleteDesc == NULL)
 		{
-			resultRelInfo->ri_deleteDesc = 
+			resultRelInfo->ri_deleteDesc =
 				appendonly_delete_init(resultRelationDesc, GetActiveSnapshot());
 		}
 
 		AOTupleId* aoTupleId = (AOTupleId*)tupleid;
 		result = appendonly_delete(resultRelInfo->ri_deleteDesc, aoTupleId);
-	} 
+	}
 	else if (isAOColsTable)
 	{
 		if (IsXactIsoLevelSerializable)
@@ -3443,16 +3443,16 @@ ldelete:;
 			if (!isUpdate)
 				ereport(ERROR,
 					   (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-						errmsg("Deletes on append-only tables are not supported in serializable transactions.")));		
+						errmsg("Deletes on append-only tables are not supported in serializable transactions.")));
 			else
 				ereport(ERROR,
 					   (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-						errmsg("Updates on append-only tables are not supported in serializable transactions.")));		
+						errmsg("Updates on append-only tables are not supported in serializable transactions.")));
 		}
 
 		if (resultRelInfo->ri_deleteDesc == NULL)
 		{
-			resultRelInfo->ri_deleteDesc = 
+			resultRelInfo->ri_deleteDesc =
 				aocs_delete_init(resultRelationDesc);
 		}
 
@@ -3469,7 +3469,7 @@ ldelete:;
 			/* already deleted by self; nothing to do */
 
 			/*
-			 * In an scenario in which R(a,b) and S(a,b) have 
+			 * In an scenario in which R(a,b) and S(a,b) have
 			 *        R               S
 			 *    ________         ________
 			 *     (1, 1)           (1, 2)
@@ -3477,12 +3477,12 @@ ldelete:;
  			 *
    			 *  An update query such as:
  			 *   UPDATE R SET a = S.b  FROM S WHERE R.b = S.a;
- 			 *   
- 			 *  will have an non-deterministic output. The tuple in R 
+ 			 *
+ 			 *  will have an non-deterministic output. The tuple in R
 			 * can be updated to (2,1) or (7,1).
- 			 * Since the introduction of SplitUpdate, these queries will 
-			 * send multiple requests to delete the same tuple. Therefore, 
-			 * in order to avoid a non-deterministic output, 
+ 			 * Since the introduction of SplitUpdate, these queries will
+			 * send multiple requests to delete the same tuple. Therefore,
+			 * in order to avoid a non-deterministic output,
 			 * an error is reported in such scenario.
  			 */
 			if (isUpdate)
@@ -4666,10 +4666,10 @@ OpenIntoRel(QueryDesc *queryDesc)
 	bool		validate_reloptions;
 
 	RelFileNode relFileNode;
-	
+
 	ItemPointerData persistentTid;
 	int64			persistentSerialNum;
-	
+
 	targetPolicy = queryDesc->plannedstmt->intoPolicy;
 
 	Assert(into);
@@ -4786,7 +4786,7 @@ OpenIntoRel(QueryDesc *queryDesc)
 	 *
 	 * GPDP does not support PITR.
 	 */
-	bufferPoolBulkLoad = 
+	bufferPoolBulkLoad =
 		(relstorage_is_buffer_pool(relstorage) ?
 									XLog_CanBypassWal() : false);
 
@@ -4836,7 +4836,7 @@ OpenIntoRel(QueryDesc *queryDesc)
 	 * And open the constructed table for writing.
 	 */
 	intoRelationDesc = heap_open(intoRelationId, AccessExclusiveLock);
-	
+
 	/*
 	 * Add column encoding entries based on the WITH clause.
 	 *
@@ -4950,7 +4950,7 @@ CloseIntoRel(QueryDesc *queryDesc)
 				{
 					bool bulkLoadFinished;
 
-					bulkLoadFinished = 
+					bulkLoadFinished =
 						MirroredBufferPool_EvaluateBulkLoadFinish(
 									myState->bulkloadinfo);
 
@@ -5127,13 +5127,13 @@ intorel_destroy(DestReceiver *self)
  * Calculate the part to use for the given key, then find or calculate
  * and cache required information about that part in the hash table
  * anchored in estate.
- * 
+ *
  * Return a pointer to the information, an entry in the table
  * estate->es_result_relations.  Note that the first entry in this
  * table is for the partitioned table itself and that the entire table
- * may be reallocated, changing the addresses of its entries.  
+ * may be reallocated, changing the addresses of its entries.
  *
- * Thus, it is important to avoid holding long-lived pointers to 
+ * Thus, it is important to avoid holding long-lived pointers to
  * table entries (such as the pointer returned from this function).
  */
 static ResultRelInfo *
@@ -5224,14 +5224,14 @@ get_part(EState *estate, Datum *values, bool *isnull, TupleDesc tupdesc)
 						  1,
 						  CMD_INSERT,
 						  estate->es_instrument);
-		
-		map_part_attrs(estate->es_result_relations->ri_RelationDesc, 
+
+		map_part_attrs(estate->es_result_relations->ri_RelationDesc,
 					   resultRelInfo->ri_RelationDesc,
 					   &(resultRelInfo->ri_partInsertMap),
 					   TRUE); /* throw on error, so result not needed */
 
 		if (resultRelInfo->ri_partInsertMap)
-			resultRelInfo->ri_partSlot = 
+			resultRelInfo->ri_partSlot =
 				MakeSingleTupleTableSlot(resultRelInfo->ri_RelationDesc->rd_att);
 	}
 	return resultRelInfo;
@@ -5287,27 +5287,27 @@ AttrMap *makeAttrMap(int base_count, AttrNumber *base_map)
 {
 	int i, n, p;
 	AttrMap *map;
-	
+
 	if ( base_count < 1 || base_map == NULL )
 		return NULL;
-	
+
 	map = palloc0(sizeof(AttrMap) + base_count * sizeof(AttrNumber));
-	
+
 	for ( i = n = p = 0; i <= base_count; i++ )
 	{
 		map->attr_map[i] = base_map[i];
-		
-		if ( map->attr_map[i] != 0 ) 
+
+		if ( map->attr_map[i] != 0 )
 		{
 			if ( map->attr_map[i] > p ) p = map->attr_map[i];
 			n++;
 		}
-	}	
-	
+	}
+
 	map->live_count = n;
 	map->attr_max = p;
 	map->attr_count = base_count;
-	
+
 	return map;
 }
 
@@ -5335,14 +5335,14 @@ static Node *apply_attrmap_mutator(Node *node, AttrMap *map)
 {
 	if ( node == NULL )
 		return NULL;
-	
+
 	if (IsA(node, Var) )
 	{
 		AttrNumber anum = 0;
 		Var *var = (Var*)node;
 		Assert(var->varno == 1); /* in CHECK constraints */
 		anum = attrMap(map, var->varattno);
-		
+
 		if ( anum == 0 )
 		{
 			/* Should never happen, but best caught early. */
@@ -5373,7 +5373,7 @@ Node *attrMapExpr(AttrMap *map, Node *expr)
  * on the segment databases as well as on the entry database.
  *
  * If requested and needed, make a vector mapping the attribute
- * numbers of the partitioned table to corresponding attribute 
+ * numbers of the partitioned table to corresponding attribute
  * numbers in the part.  Represent the "unneeded" identity map
  * as null.
  *
@@ -5391,18 +5391,18 @@ Node *attrMapExpr(AttrMap *map, Node *expr)
  * with the base relation.  If the throw argument is true, however,
  * an error is issued rather than returning false.
  *
- * Note that, in the map, element 0 is wasted and is always zero, 
+ * Note that, in the map, element 0 is wasted and is always zero,
  * so the vector is indexed by attribute number (origin 1).
  *
- * The i-th element of the map is the attribute number in 
- * the part relation that corresponds to attribute i of the  
- * base relation, or it is zero to indicate that attribute 
+ * The i-th element of the map is the attribute number in
+ * the part relation that corresponds to attribute i of the
+ * base relation, or it is zero to indicate that attribute
  * i of the base relation doesn't exist (has been dropped).
  *
  * This is a handy map for renumbering attributes for use with
- * part relations that may have a different configuration of 
+ * part relations that may have a different configuration of
  * "holes" than the partitioned table in which they occur.
- * 
+ *
  * Be sure to call this in the memory context in which the result
  * vector ought to be stored.
  *
@@ -5411,57 +5411,57 @@ Node *attrMapExpr(AttrMap *map, Node *expr)
  * correct, errors should not occur.  Still, the downside is
  * incorrect data, so use errors (not assertions) for the case.
  *
- * Checks include same number of non-dropped attributes in all 
- * parts of a partitioned table, non-dropped attributes in 
+ * Checks include same number of non-dropped attributes in all
+ * parts of a partitioned table, non-dropped attributes in
  * corresponding relative positions must match in name, type
  * and alignment, attribute numbers must agree with their
  * position in tuple, etc.
  */
-bool 
+bool
 map_part_attrs(Relation base, Relation part, AttrMap **map_ptr, bool throw)
-{	
+{
 	AttrNumber i = 1;
 	AttrNumber n = base->rd_att->natts;
 	FormData_pg_attribute *battr = NULL;
-	
+
 	AttrNumber j = 1;
 	AttrNumber m = part->rd_att->natts;
 	FormData_pg_attribute *pattr = NULL;
-	
+
 	AttrNumber *v = NULL;
-	
+
 	/* If we might want a map, allocate one. */
 	if ( map_ptr != NULL )
 	{
 		v = palloc0(sizeof(AttrNumber)*(n+1));
 		*map_ptr = NULL;
 	}
-	
+
 	bool is_identical = TRUE;
 	bool is_compatible = TRUE;
-	
+
 	/* For each matched pair of attributes ... */
 	while ( i <= n && j <= m )
 	{
 		battr = base->rd_att->attrs[i-1];
 		pattr = part->rd_att->attrs[j-1];
-		
+
 		/* Skip dropped attributes. */
-		
+
 		if ( battr->attisdropped )
 		{
 			i++;
 			continue;
 		}
-		
+
 		if ( pattr->attisdropped )
 		{
 			j++;
 			continue;
 		}
-		
+
 		/* Check attribute conformability requirements. */
-		
+
 		/* -- Names must match. */
 		if ( strncmp(NameStr(battr->attname), NameStr(pattr->attname), NAMEDATALEN) != 0 )
 		{
@@ -5475,7 +5475,7 @@ map_part_attrs(Relation base, Relation part, AttrMap **map_ptr, bool throw)
 			is_compatible = FALSE;
 			break;
 		}
-		
+
 		/* -- Types must match. */
 		if (battr->atttypid != pattr->atttypid)
 		{
@@ -5487,7 +5487,7 @@ map_part_attrs(Relation base, Relation part, AttrMap **map_ptr, bool throw)
 			is_compatible = FALSE;
 			break;
 		}
-		
+
 		/* -- Alignment should match, but check just to be safe. */
 		if (battr->attalign != pattr->attalign )
 		{
@@ -5499,28 +5499,28 @@ map_part_attrs(Relation base, Relation part, AttrMap **map_ptr, bool throw)
 			is_compatible = FALSE;
 			break;
 		}
-		
-		/* -- Attribute numbers must match position (+1) in tuple. 
+
+		/* -- Attribute numbers must match position (+1) in tuple.
 		 *    This is a hard requirement so always throw.  This could
-		 *    be an assertion, except that we want to fail even in a 
+		 *    be an assertion, except that we want to fail even in a
 		 *    distribution build.
 		 */
 		if ( battr->attnum != i || pattr->attnum != j )
 			elog(ERROR,
 				 "attribute numbers out of order");
-		
+
 		/* Note any attribute number difference. */
 		if ( i != j )
 			is_identical = FALSE;
-		
+
 		/* If we're building a map, update it. */
 		if ( v != NULL )
 			v[i] = j;
-		
+
 		i++;
 		j++;
 	}
-	
+
 	if ( is_compatible )
 	{
 		/* Any excess attributes in parent better be marked dropped */
@@ -5561,7 +5561,7 @@ map_part_attrs(Relation base, Relation part, AttrMap **map_ptr, bool throw)
 	{
 		is_identical = FALSE;
 	}
-	
+
 	if ( !is_compatible )
 	{
 		Assert( !throw );
@@ -5576,7 +5576,7 @@ map_part_attrs(Relation base, Relation part, AttrMap **map_ptr, bool throw)
 		pfree(v);
 		v = NULL;
 	}
-	
+
 	if ( map_ptr != NULL && v != NULL )
 	{
 		*map_ptr = makeAttrMap(n, v);

--- a/src/backend/executor/execTuples.c
+++ b/src/backend/executor/execTuples.c
@@ -431,7 +431,7 @@ ExecStoreMinimalTuple(MemTuple mtup,
 	 * Free any old physical tuple belonging to the slot.
 	 */
 	free_heaptuple_memtuple(slot);
-	
+
 	/*
 	 * Store the new tuple into the specified slot.
 	 */
@@ -540,7 +540,7 @@ ExecStoreVirtualTuple(TupleTableSlot *slot)
 	 */
 	Assert(slot != NULL);
 	Assert(slot->tts_tupleDescriptor != NULL);
-	
+
 	TupClearIsEmpty(slot);
 	TupSetVirtualTuple(slot);
 
@@ -641,7 +641,7 @@ ExecCopySlotMemTuple(TupleTableSlot *slot)
 	 */
 	if (slot->PRIVATE_tts_memtuple)
 		return memtuple_copy_to(slot->PRIVATE_tts_memtuple, NULL, NULL);
-	
+
 	slot_getallattrs(slot);
 
 	/*
@@ -661,7 +661,7 @@ ExecCopySlotMemTupleTo(TupleTableSlot *slot, MemoryContext pctxt, char *dest, un
 
 	if(!len)
 		len = &dumlen;
-	
+
 	if (TupHasMemTuple(slot))
 	{
 		mtup = memtuple_copy_to(slot->PRIVATE_tts_memtuple, (MemTuple) dest, len);
@@ -686,7 +686,7 @@ ExecCopySlotMemTupleTo(TupleTableSlot *slot, MemoryContext pctxt, char *dest, un
 	Assert(mtup);
 	return mtup;
 }
-		
+
 /* --------------------------------
  *		ExecFetchSlotTuple
  *			Fetch the slot's regular physical tuple.
@@ -727,7 +727,7 @@ ExecFetchSlotHeapTuple(TupleTableSlot *slot)
 	tuplen = slot->PRIVATE_tts_htup_buf_len;
 	htup = heaptuple_form_to(slot->tts_tupleDescriptor, slot_get_values(slot), slot_get_isnull(slot),
 			slot->PRIVATE_tts_htup_buf, &tuplen);
-	
+
 	if(!htup)
 	{
 		if(slot->PRIVATE_tts_htup_buf)
@@ -880,7 +880,7 @@ void ExecModifyMemTuple(TupleTableSlot *slot, Datum *values, bool *isnull, bool 
 	 */
 	slot->PRIVATE_tts_nvalid = 0;
 	slot_getallattrs(slot);
-	
+
 	/* Next, we construct a new memtuple, on the htup buf to avoid palloc */
 	slot->PRIVATE_tts_heaptuple = NULL;
 	for(i = 0; i<slot->tts_tupleDescriptor->natts; ++i)
@@ -963,7 +963,7 @@ ExecInitResultTupleSlot(EState *estate, PlanState *planstate)
  *      so they can be reused for each tuple.  They're initialized here.
  *      During execution, Var nodes referencing system-defined attrs can
  *      occur only in the targetlist and qual exprs attached to a scan
- *      operator.  Those exprs are evaluated taking their input from the 
+ *      operator.  Those exprs are evaluated taking their input from the
  *      scan operator's Scan Tuple Slot.
  * ----------------
  */
@@ -1365,7 +1365,7 @@ slot_getsysattr(TupleTableSlot *slot, int attnum, bool *isnull)
                 {
                         case SelfItemPointerAttributeNumber:
 							Assert(ItemPointerIsValid(&(htup->t_self)));
-							
+
 							result = PointerGetDatum(&(htup->t_self));
 							break;
                         case ObjectIdAttributeNumber:
@@ -1383,7 +1383,7 @@ slot_getsysattr(TupleTableSlot *slot, int attnum, bool *isnull)
         else
         {
 			Assert(TupHasMemTuple(slot) || TupHasVirtualTuple(slot));
-			
+
                 switch(attnum)
                 {
                         case SelfItemPointerAttributeNumber:

--- a/src/backend/executor/execTuples.c
+++ b/src/backend/executor/execTuples.c
@@ -1447,3 +1447,62 @@ slot_set_ctid_from_fake(TupleTableSlot *slot, ItemPointerData *fake_ctid)
 
 	slot_set_ctid(slot, fake_ctid);
 }
+
+HeapTuple
+ExecMaterializeSlotHeapTuple(TupleTableSlot *slot)
+{
+	uint32 tuplen;
+	HeapTuple htup;
+
+	/*
+	 * sanity checks
+	 */
+	Assert(!TupIsNull(slot));
+
+	/*
+	 * If we have a regular physical tuple, and it's locally palloc'd, we have
+	 * nothing to do.
+	 *
+	 * GPDB_84_MERGE_FIXME: do we need to utilize the "shouldFree" logic that's
+	 * set up elsewhere? We would need to update this function and others to set
+	 * the SHOULDFREE flag when appropriate.
+	 */
+	if (slot->PRIVATE_tts_heaptuple && TupShouldFree(slot))
+		return slot->PRIVATE_tts_heaptuple;
+
+	/*
+	 * If we already materialized heap tuple before, just return it to avoid
+	 * duplicated construction.
+	 */
+	if (slot->PRIVATE_tts_heaptuple &&
+		(slot->PRIVATE_tts_heaptuple == slot->PRIVATE_tts_htup_buf))
+		return slot->PRIVATE_tts_heaptuple;
+
+	slot_getallattrs(slot);
+
+	Assert(TupHasVirtualTuple(slot));
+	Assert(slot->PRIVATE_tts_nvalid == slot->tts_tupleDescriptor->natts);
+
+	/* Get the length of the buffer we need to allocate. */
+	tuplen = 0;
+	htup = heaptuple_form_to(slot->tts_tupleDescriptor, slot_get_values(slot),
+							 slot_get_isnull(slot), slot->PRIVATE_tts_htup_buf,
+							 &tuplen);
+	Assert(!htup);
+
+	/* Allocate. */
+	if(slot->PRIVATE_tts_htup_buf)
+		pfree(slot->PRIVATE_tts_htup_buf);
+	slot->PRIVATE_tts_htup_buf = (HeapTuple) MemoryContextAlloc(slot->tts_mcxt,
+																tuplen);
+	slot->PRIVATE_tts_htup_buf_len = tuplen;
+
+	/* Materialize in the allocated buffer. */
+	htup = heaptuple_form_to(slot->tts_tupleDescriptor, slot_get_values(slot),
+							 slot_get_isnull(slot), slot->PRIVATE_tts_htup_buf,
+							 &tuplen);
+	Assert(htup);
+
+	slot->PRIVATE_tts_heaptuple = htup;
+	return htup;
+}

--- a/src/include/executor/tuptable.h
+++ b/src/include/executor/tuptable.h
@@ -135,7 +135,7 @@ typedef struct TupleTableSlot
 	void 	*PRIVATE_tts_mtup_buf;
 	uint32  PRIVATE_tts_mtup_buf_len;
 	ItemPointerData PRIVATE_tts_synthetic_ctid;	/* needed if memtuple is stored on disk */
-	
+
 	/* Virtual tuple stuff */
 	int 	PRIVATE_tts_nvalid;		/* number of valid virtual tup entries */
 	long    PRIVATE_tts_off; 		/* hack to remember state of last decoding. */
@@ -144,7 +144,7 @@ typedef struct TupleTableSlot
 	bool 	*PRIVATE_tts_isnull;		/* virtual tuple nulls */
 
 	TupleDesc	tts_tupleDescriptor;	/* slot's tuple descriptor */
-	MemTupleBinding *tts_mt_bind;		/* mem tuple's binding */ 
+	MemTupleBinding *tts_mt_bind;		/* mem tuple's binding */
 	MemoryContext 	tts_mcxt;		/* slot itself is in this context */
 	Buffer		tts_buffer;		/* tuple's buffer, or InvalidBuffer */
 
@@ -163,11 +163,11 @@ static inline void TupClearIsEmpty(TupleTableSlot *slot)
 static inline bool TupShouldFree(TupleTableSlot *slot)
 {
 	Assert(slot);
-	return ((slot->PRIVATE_tts_flags & TTS_SHOULDFREE) != 0); 
+	return ((slot->PRIVATE_tts_flags & TTS_SHOULDFREE) != 0);
 }
 static inline void TupSetShouldFree(TupleTableSlot *slot)
 {
-	slot->PRIVATE_tts_flags |= TTS_SHOULDFREE; 
+	slot->PRIVATE_tts_flags |= TTS_SHOULDFREE;
 }
 static inline void TupClearShouldFree(TupleTableSlot *slot)
 {
@@ -191,7 +191,7 @@ static inline bool TupHasVirtualTuple(TupleTableSlot *slot)
 static inline HeapTuple TupGetHeapTuple(TupleTableSlot *slot)
 {
 	Assert(TupHasHeapTuple(slot));
-	return slot->PRIVATE_tts_heaptuple; 
+	return slot->PRIVATE_tts_heaptuple;
 }
 static inline MemTuple TupGetMemTuple(TupleTableSlot *slot)
 {
@@ -205,7 +205,7 @@ static inline void free_heaptuple_memtuple(TupleTableSlot *slot)
 	{
 		if(slot->PRIVATE_tts_heaptuple && slot->PRIVATE_tts_heaptuple != slot->PRIVATE_tts_htup_buf)
 			pfree(slot->PRIVATE_tts_heaptuple);
-		
+
 		if(slot->PRIVATE_tts_memtuple && slot->PRIVATE_tts_memtuple != slot->PRIVATE_tts_mtup_buf)
 			pfree(slot->PRIVATE_tts_memtuple);
 	}
@@ -249,10 +249,10 @@ static inline void slot_getsomeattrs(TupleTableSlot *slot, int attnum)
 
 	if(TupHasMemTuple(slot))
 	{
-		int i; 
+		int i;
 		for(i=0; i<attnum; ++i)
 			slot->PRIVATE_tts_values[i] = memtuple_getattr(
-					slot->PRIVATE_tts_memtuple, slot->tts_mt_bind, 
+					slot->PRIVATE_tts_memtuple, slot->tts_mt_bind,
 					i+1, &(slot->PRIVATE_tts_isnull[i]));
 
 		TupSetVirtualTuple(slot);
@@ -260,7 +260,7 @@ static inline void slot_getsomeattrs(TupleTableSlot *slot, int attnum)
 		return;
 	}
 
-	_slot_getsomeattrs(slot, attnum); 
+	_slot_getsomeattrs(slot, attnum);
 	TupSetVirtualTuple(slot);
 }
 
@@ -291,7 +291,7 @@ static inline void slot_set_ctid(TupleTableSlot *slot, ItemPointer new_ctid)
 		HeapTuple tuple = TupGetHeapTuple(slot);
 		tuple->t_self = *new_ctid;
 	}
-	
+
 	if (TupHasMemTuple(slot) || TupHasVirtualTuple(slot))
 		slot->PRIVATE_tts_synthetic_ctid = *new_ctid;
 }
@@ -311,7 +311,7 @@ static inline ItemPointer slot_get_ctid(TupleTableSlot *slot)
 		Assert(ItemPointerIsValid(&(slot->PRIVATE_tts_heaptuple->t_self)));
 		return &(slot->PRIVATE_tts_heaptuple->t_self);
 	}
-	
+
 	return &(slot->PRIVATE_tts_synthetic_ctid);
 }
 
@@ -357,7 +357,7 @@ static inline bool slot_attisnull(TupleTableSlot *slot, int attnum)
 
 	if(TupHasHeapTuple(slot))
 		return heap_attisnull_normalattr(slot->PRIVATE_tts_heaptuple, attnum);
-		
+
 	if(TupHasVirtualTuple(slot) && slot->PRIVATE_tts_nvalid >= attnum)
 		return slot->PRIVATE_tts_isnull[attnum-1];
 
@@ -378,7 +378,7 @@ extern TupleTableSlot *ExecAllocTableSlot(List **tupleTable);
 extern void ExecResetTupleTable(List *tupleTable, bool shouldFree);
 extern TupleTableSlot *MakeSingleTupleTableSlot(TupleDesc tupdesc);
 extern void ExecDropSingleTupleTableSlot(TupleTableSlot *slot);
-extern void ExecSetSlotDescriptor(TupleTableSlot *slot, TupleDesc tupdesc); 
+extern void ExecSetSlotDescriptor(TupleTableSlot *slot, TupleDesc tupdesc);
 
 extern TupleTableSlot *ExecStoreHeapTuple(HeapTuple tuple,
 			   TupleTableSlot *slot,

--- a/src/include/executor/tuptable.h
+++ b/src/include/executor/tuptable.h
@@ -432,5 +432,6 @@ ExecCopyGenericTuple(TupleTableSlot *slot)
 extern TupleTableSlot *ExecCopySlot(TupleTableSlot *dstslot, TupleTableSlot *srcslot);
 
 extern void ExecModifyMemTuple(TupleTableSlot *slot, Datum *values, bool *isnull, bool *doRepl);
+extern HeapTuple ExecMaterializeSlotHeapTuple(TupleTableSlot *slot);
 
 #endif   /* TUPTABLE_H */

--- a/src/test/regress/duplicate_oids_test.c
+++ b/src/test/regress/duplicate_oids_test.c
@@ -1,0 +1,36 @@
+#include "postgres.h"
+
+#include "funcapi.h"
+#include "commands/trigger.h"
+
+extern Datum trigger_udf_return_new_oid(PG_FUNCTION_ARGS);
+
+/*
+ * trigger_udf_return_new_oid
+ *   Scalar returning function - create a new tuple copied base on the input tuple, but
+ *   set a new oid.
+ */
+PG_FUNCTION_INFO_V1(trigger_udf_return_new_oid);
+Datum
+trigger_udf_return_new_oid(PG_FUNCTION_ARGS)
+{
+	TriggerData		*trigger_data = (TriggerData*)fcinfo->context;
+	HeapTuple		input_tuple;
+	HeapTuple		ret_tuple;
+	Oid				new_oid = PG_GETARG_OID(0);
+
+    if (!CALLED_AS_TRIGGER(fcinfo))
+        ereport(ERROR,
+            (errcode(ERRCODE_TRIGGERED_ACTION_EXCEPTION),
+             errmsg("not called by trigger manager")));
+
+    if (!TRIGGER_FIRED_BY_INSERT(trigger_data->tg_event))
+        ereport(ERROR,
+            (errcode(ERRCODE_TRIGGERED_ACTION_EXCEPTION),
+             errmsg("not called on valid event")));
+
+	input_tuple = trigger_data->tg_trigtuple;
+	ret_tuple = heap_copytuple(input_tuple);
+	HeapTupleSetOid(ret_tuple, new_oid);
+	return PointerGetDatum(ret_tuple);
+}

--- a/src/test/regress/input/duplicate_oids_test.source
+++ b/src/test/regress/input/duplicate_oids_test.source
@@ -1,0 +1,12 @@
+CREATE OR REPLACE FUNCTION trigger_return_new_oid(Oid)
+RETURNS trigger
+LANGUAGE C VOLATILE EXECUTE ON MASTER AS '@abs_builddir@/regress@DLSUFFIX@', 'trigger_udf_return_new_oid';
+
+CREATE OR REPLACE TABLE foo_oid(id int8, v text) WITH(OIDS=TRUE) DISTRIBUTED BY(id);
+
+CREATE TRIGGER t BEFORE INSERT ON foo_oid
+FOR EACH ROW EXECUTE PROCEDURE trigger_return_new_oid(20000);
+
+CREATE OR REPLACE TABLE foo_without_oid(id int8, v text) WITH(OIDS=TRUE) DISTRIBUTED BY(id);
+CREATE TRIGGER t BEFORE INSERT ON foo_without_oid
+FOR EACH ROW EXECUTE PROCEDURE trigger_return_new_oid(20000);


### PR DESCRIPTION
    Use ExecMaterializeSlotHeapTuple to make writable copy so
    that we are safe to modify HeapTuple in place.
    This fix following problems(Insert and Update):
    1) Insert:
    set optimizer=off;
    CREATE TABLE dml_heap_r (a int , b int default -1, c text) WITH OIDS DISTRIBUTED BY (a);
    INSERT INTO dml_heap_r VALUES(generate_series(1,2),generate_series(1,2),'r');
    INSERT INTO dml_heap_r VALUES(NULL,NULL,NULL);
    SELECT OID,* FROM dml_heap_r;

    2) Update:
    CREATE TABLE dml_heap_r (a int , b int default -1, c text) WITH OIDS DISTRIBUTED BY (a);
    INSERT INTO dml_heap_r VALUES(generate_series(1,2),generate_series(1,2),'r');
    SELECT OID,* FROM dml_heap_r;
    UPDATE dml_heap_r SET b=1;
    SELECT OID,* FROM dml_heap_r;

    Still run for ICW local. It seems OID uniqueness cannot be guaranteed if on different segment? Need to verify whether it is a bug to be fixed.