### PR TITLE
Bitmap index scan returns empty bitmap instead of NULL pointer

### DIFF
--- a/src/backend/executor/execBitmapTableScan.c
+++ b/src/backend/executor/execBitmapTableScan.c
@@ -151,8 +151,7 @@ readBitmap(BitmapTableScanState *scanState)
 
 	Node *tbm = (Node *) MultiExecProcNode(outerPlanState(scanState));
 
-	if (tbm != NULL && (!(IsA(tbm, TIDBitmap) ||
-						  IsA(tbm, StreamBitmap))))
+	if (!tbm || (!(IsA(tbm, TIDBitmap) || IsA(tbm, StreamBitmap))))
 	{
 		elog(ERROR, "unrecognized result from subplan");
 	}

--- a/src/backend/executor/nodeBitmapAppendOnlyscan.c
+++ b/src/backend/executor/nodeBitmapAppendOnlyscan.c
@@ -286,8 +286,7 @@ BitmapAppendOnlyScanNext(BitmapAppendOnlyScanState *node)
 	{
 		Node *tbm = (Node *) MultiExecProcNode(outerPlanState(node));
 
-		if (tbm != NULL && (!(IsA(tbm, TIDBitmap) ||
-							  IsA(tbm, StreamBitmap))))
+		if (!tbm || (!(IsA(tbm, TIDBitmap) || IsA(tbm, StreamBitmap))))
 			elog(ERROR, "unrecognized result from subplan");
 
 		if (tbm == NULL)

--- a/src/backend/executor/nodeBitmapHeapscan.c
+++ b/src/backend/executor/nodeBitmapHeapscan.c
@@ -213,13 +213,11 @@ BitmapHeapNext(BitmapHeapScanState *node)
 	{
 		tbm = (Node *) MultiExecProcNode(outerPlanState(node));
 
-		if (tbm != NULL && (!(IsA(tbm, TIDBitmap) || IsA(tbm, StreamBitmap))))
+		if (!tbm || !IsA(tbm, TIDBitmap) || IsA(tbm, StreamBitmap))
 			elog(ERROR, "unrecognized result from subplan");
 
 		node->tbm = tbm;
-
-		if (tbm != NULL)
-			node->tbmiterator = tbmiterator = tbm_generic_begin_iterate(tbm);
+		node->tbmiterator = tbmiterator = tbm_generic_begin_iterate(tbm);
 
 #ifdef USE_PREFETCH
 		if (target_prefetch_pages > 0)

--- a/src/backend/executor/nodeBitmapHeapscan.c
+++ b/src/backend/executor/nodeBitmapHeapscan.c
@@ -213,7 +213,7 @@ BitmapHeapNext(BitmapHeapScanState *node)
 	{
 		tbm = (Node *) MultiExecProcNode(outerPlanState(node));
 
-		if (!tbm || !IsA(tbm, TIDBitmap) || IsA(tbm, StreamBitmap))
+		if (!tbm || !(IsA(tbm, TIDBitmap) || IsA(tbm, StreamBitmap)))
 			elog(ERROR, "unrecognized result from subplan");
 
 		node->tbm = tbm;

--- a/src/backend/executor/nodeBitmapIndexscan.c
+++ b/src/backend/executor/nodeBitmapIndexscan.c
@@ -122,6 +122,10 @@ MultiExecBitmapIndexScan(BitmapIndexScanState *node)
 	if (node->ss.ps.instrument)
 		InstrStopNode(node->ss.ps.instrument, 1 /* nTuples */);
 
+	if (NULL == bitmap)
+		/* XXX should we use less than work_mem for this? */
+		bitmap = (Node*) tbm_create(work_mem * 1024L);
+
 	return (Node *) bitmap;
 }
 


### PR DESCRIPTION
1. Revert previous special check but follow PG style
2 .Force MultiExecBitmapIndexScan returns empty bitmap instead of NULL to keep as the same behavior as that of the upstream referring PG commit: 9d64632144034cd6b0a32bad1c3a305008149754