### PR TITLE
(WIP) Fix insert into failure when orca is disabled.

### DIFF
--- a/src/backend/cdb/cdbsubplan.c
+++ b/src/backend/cdb/cdbsubplan.c
@@ -30,6 +30,7 @@ typedef struct ParamWalkerContext
 								 * plan_tree_walker/mutator */
 	List	   *params;
 	Bitmapset  *wtParams;
+	Bitmapset  *epqParams;
 } ParamWalkerContext;
 
 static bool param_walker(Node *node, ParamWalkerContext *context);
@@ -230,6 +231,7 @@ addRemoteExecParamsToParamList(PlannedStmt *stmt, ParamListInfo extPrm, ParamExe
 	exec_init_plan_tree_base(&context.base, stmt);
 	context.params = NIL;
 	context.wtParams = NULL;
+	context.epqParams = NULL;
 	param_walker((Node *) plan, &context);
 
 	/*
@@ -268,7 +270,8 @@ addRemoteExecParamsToParamList(PlannedStmt *stmt, ParamListInfo extPrm, ParamExe
 		}
 	}
 
-	if (context.params == NIL && bms_num_members(context.wtParams) < nIntPrm)
+	if (context.params == NIL &&
+		bms_num_members(context.wtParams) + bms_num_members(context.epqParams) < nIntPrm)
 	{
 		/*
 		 * We apparently have an initplan with no corresponding parameter.
@@ -380,6 +383,11 @@ param_walker(Node *node, ParamWalkerContext *context)
 		WorkTableScan *wt = (WorkTableScan *) node;
 
 		context->wtParams = bms_add_member(context->wtParams, wt->wtParam);
+	}
+	else if (IsA(node, ModifyTable))
+	{
+		ModifyTable	*mt	= (ModifyTable *) node;
+		context->epqParams = bms_add_member(context->epqParams, mt->epqParam);
 	}
 	return plan_tree_walker(node, param_walker, context);
 }

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -2780,6 +2780,23 @@ _readAccessPriv(void)
 	READ_DONE();
 }
 
+static ModifyTable *
+_readModifyTable(void)
+{
+	READ_LOCALS(ModifyTable);
+
+	readPlanInfo((Plan *)local_node);
+	READ_ENUM_FIELD(operation, CmdType);
+	READ_NODE_FIELD(resultRelations);
+	READ_NODE_FIELD(plans);
+	READ_NODE_FIELD(returningLists);
+	READ_NODE_FIELD(rowMarks);
+	READ_INT_FIELD(epqParam);
+
+	READ_DONE();
+}
+
+
 static Node *
 _readValue(NodeTag nt)
 {
@@ -3664,6 +3681,9 @@ readNodeBinary(void)
 				break;
 			case T_CreateFdwStmt:
 				return_value = _readCreateFdwStmt();
+				break;
+			case T_ModifyTable:
+				return_value = _readModifyTable();
 				break;
 
 

--- a/src/backend/postmaster/autostats.c
+++ b/src/backend/postmaster/autostats.c
@@ -65,7 +65,7 @@ autostats_issue_analyze(Oid relationOid)
 	relation = makeRangeVar(get_namespace_name(get_rel_namespace(relationOid)), get_rel_name(relationOid), -1);
 	analyzeStmt = makeNode(VacuumStmt);
 	/* Set up command parameters */
-	analyzeStmt->options = 0;
+	analyzeStmt->options = VACOPT_ANALYZE;
 	analyzeStmt->freeze_min_age = -1;
 	analyzeStmt->relation = relation;	/* not used since we pass relids list */
 	analyzeStmt->va_cols = NIL;


### PR DESCRIPTION
In upstream, we add a new node ModifyTable which has null targetlist.
We should create hashExpr for its child plan instead of based on ModifyTable itself.
This fix also includes some minor checks failure as well as auto_stats incorrect option setting fix.
There still exists other failures with updates. Will fix it in other PR