### PR TITLE
Make simple update works.

### DIFF
--- a/src/backend/cdb/cdbmutate.c
+++ b/src/backend/cdb/cdbmutate.c
@@ -248,7 +248,7 @@ apply_motion(PlannerInfo *root, Plan *plan, Query *query)
 	state.initPlans = NIL;
 
 	Assert(is_plan_node((Node *) plan) && IsA(query, Query));
-	Assert(plan->flow && plan->flow->flotype != FLOW_REPLICATED);
+	Assert(IsA(plan, ModifyTable) || (plan->flow && plan->flow->flotype != FLOW_REPLICATED));
 
 	/* Does query have a target relation?  (INSERT/DELETE/UPDATE) */
 

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -852,7 +852,8 @@ subquery_planner(PlannerGlobal *glob, Query *parse,
 											 returningLists,
 											 rowMarks,
 											 SS_assign_special_param(root));
-			plan->flow = pull_up_Flow(plan, getAnySubplan(plan));
+			if (!IsA(plan, ModifyTable))
+				plan->flow = pull_up_Flow(plan, getAnySubplan(plan));
 		}
 	}
 


### PR DESCRIPTION
We don't need to generate flow for ModifyTable node because its children plan
includes motion already.

Author: Xiaoran Wang <xiwang@pivotal.io>
Author: Max Yang <myang@pivotal.io>