### PR TITLE
Get auth_constraint tests passing again

### DIFF
--- a/src/backend/catalog/catalog.c
+++ b/src/backend/catalog/catalog.c
@@ -461,7 +461,8 @@ IsSharedRelation(Oid relationId)
 		relationId == AuthIdRolResQueueIndexId ||
 		relationId == AuthIdRolResGroupIndexId ||
 		relationId == GpSegmentConfigContentPreferred_roleIndexId ||
-		relationId == GpSegmentConfigDbidIndexId)
+		relationId == GpSegmentConfigDbidIndexId ||
+		relationId == AuthTimeConstraintAuthIdIndexId)
 	{
 		return true;
 	}

--- a/src/backend/catalog/catalog.c
+++ b/src/backend/catalog/catalog.c
@@ -467,9 +467,7 @@ IsSharedRelation(Oid relationId)
 	}
 
 	/* These are their toast tables and toast indexes (see toasting.h) */
-	if (relationId == PgAuthidToastTable ||
-		relationId == PgAuthidToastIndex ||
-		relationId == PgDatabaseToastTable ||
+	if (relationId == PgDatabaseToastTable ||
 		relationId == PgDatabaseToastIndex ||
 		relationId == PgShdescriptionToastTable ||
 		relationId == PgShdescriptionToastIndex ||

--- a/src/backend/utils/cache/relcache.c
+++ b/src/backend/utils/cache/relcache.c
@@ -2874,11 +2874,11 @@ RelationCacheInitializePhase2(void)
 	 */
 	if (!load_relcache_init_file(true))
 	{
-		formrdesc("pg_database", PG_DATABASE_RELTYPE_OID, true,
+		formrdesc("pg_database", DatabaseRelation_Rowtype_Id, true,
 				  true, Natts_pg_database, Desc_pg_database);
-		formrdesc("pg_authid", PG_AUTHID_RELTYPE_OID, true,
+		formrdesc("pg_authid", AuthIdRelation_Rowtype_Id, true,
 				  true, Natts_pg_authid, Desc_pg_authid);
-		formrdesc("pg_auth_members", PG_AUTH_MEMBERS_RELTYPE_OID, true,
+		formrdesc("pg_auth_members", AuthMemRelation_Rowtype_Id, true,
 				  false, Natts_pg_auth_members, Desc_pg_auth_members);
 
 #define NUM_CRITICAL_SHARED_RELS	3	/* fix if you change list above */

--- a/src/include/catalog/catversion.h
+++ b/src/include/catalog/catversion.h
@@ -56,6 +56,6 @@
  */
 
 /*							3yyymmddN */
-#define CATALOG_VERSION_NO	301801211
+#define CATALOG_VERSION_NO	301801241
 
 #endif

--- a/src/include/catalog/indexing.h
+++ b/src/include/catalog/indexing.h
@@ -103,6 +103,9 @@ DECLARE_UNIQUE_INDEX(pg_auth_members_role_member_index, 2694, on pg_auth_members
 DECLARE_UNIQUE_INDEX(pg_auth_members_member_role_index, 2695, on pg_auth_members using btree(member oid_ops, roleid oid_ops));
 #define AuthMemMemRoleIndexId	2695
 
+DECLARE_INDEX(pg_auth_time_constraint_authid_index, 6449, on pg_auth_time_constraint using btree(authid oid_ops));
+#define AuthTimeConstraintAuthIdIndexId	6449
+
 DECLARE_UNIQUE_INDEX(pg_cast_oid_index, 2660, on pg_cast using btree(oid oid_ops));
 #define CastOidIndexId	2660
 DECLARE_UNIQUE_INDEX(pg_cast_source_target_index, 2661, on pg_cast using btree(castsource oid_ops, casttarget oid_ops));

--- a/src/include/catalog/pg_auth_members.h
+++ b/src/include/catalog/pg_auth_members.h
@@ -27,8 +27,9 @@
  * ----------------
  */
 #define AuthMemRelationId	1261
+#define AuthMemRelation_Rowtype_Id	2843
 
-CATALOG(pg_auth_members,1261) BKI_SHARED_RELATION BKI_WITHOUT_OIDS
+CATALOG(pg_auth_members,1261) BKI_SHARED_RELATION BKI_WITHOUT_OIDS BKI_ROWTYPE_OID(2843)
 {
 	Oid			roleid;			/* ID of a role */
 	Oid			member;			/* ID of a member of that role */

--- a/src/include/catalog/pg_auth_time_constraint.h
+++ b/src/include/catalog/pg_auth_time_constraint.h
@@ -35,8 +35,9 @@
  * ----------------
  */
 #define AuthTimeConstraintRelationId	6070
+#define AuthTimeConstraint_Rowtype_Id	6071
 
-CATALOG(pg_auth_time_constraint,6070) BKI_SHARED_RELATION BKI_WITHOUT_OIDS
+CATALOG(pg_auth_time_constraint,6070) BKI_SHARED_RELATION BKI_WITHOUT_OIDS BKI_ROWTYPE_OID(6071)
 {
 	Oid		authid;		/* foreign key to pg_authid.oid, */
 	int2	start_day;	/* [0,6] denoting start of interval */
@@ -70,5 +71,12 @@ typedef FormData_pg_auth_time_constraint *Form_pg_auth_time_constraint;
 #define Anum_pg_auth_time_constraint_start_time	3
 #define Anum_pg_auth_time_constraint_end_day	4
 #define Anum_pg_auth_time_constraint_end_time	5
+
+#define Schema_pg_auth_time_constraint \
+{6070, {"authid"}    ,   26, -1, 0, 4, 1, 0, -1, -1, true           , 'p' ,'i', true, false, false, true, 0, { 0 } }, \
+{6070, {"start_day"} ,   21, -1, 0, 2, 2, 0, -1, -1, true           , 'p' ,'s', true, false, false, true, 0, { 0 } }, \
+{6070, {"start_time"}, 1083, -1, 0, 8, 3, 0, -1, -1, FLOAT8PASSBYVAL, 'p' ,'d', true, false, false, true, 0, { 0 } }, \
+{6070, {"end_day"}   ,   21, -1, 0, 2, 4, 0, -1, -1, true           , 'p' ,'s', true, false, false, true, 0, { 0 } }, \
+{6070, {"end_time"}  , 1083, -1, 0, 8, 5, 0, -1, -1, FLOAT8PASSBYVAL, 'p' ,'d', true, false, false, true, 0, { 0 } }
 
 #endif   /* PG_AUTH_TIME_CONSTRAINT_H */

--- a/src/include/catalog/pg_authid.h
+++ b/src/include/catalog/pg_authid.h
@@ -42,8 +42,9 @@
  * ----------------
  */
 #define AuthIdRelationId	1260
+#define AuthIdRelation_Rowtype_Id	2842
 
-CATALOG(pg_authid,1260) BKI_SHARED_RELATION
+CATALOG(pg_authid,1260) BKI_SHARED_RELATION BKI_ROWTYPE_OID(2842)
 {
 	NameData	rolname;		/* name of role */
 	bool		rolsuper;		/* read this field via superuser() only! */

--- a/src/include/catalog/pg_type.h
+++ b/src/include/catalog/pg_type.h
@@ -351,15 +351,6 @@ DATA(insert OID = 75 (	pg_attribute	PGNSP PGUID -1 f c C f t \054 1249 0 0 recor
 DATA(insert OID = 81 (	pg_proc			PGNSP PGUID -1 f c C f t \054 1255 0 0 record_in record_out record_recv record_send - - - d x f 0 -1 0 _null_ _null_ ));
 DATA(insert OID = 83 (	pg_class		PGNSP PGUID -1 f c C f t \054 1259 0 0 record_in record_out record_recv record_send - - - d x f 0 -1 0 _null_ _null_ ));
 
-DATA(insert OID = 2842 (	pg_authid	   PGNSP PGUID -1 f c C f t \054 1260 0 0 record_in record_out record_recv record_send - - - d x f 0 -1 0 _null_ _null_ ));
-#define PG_AUTHID_RELTYPE_OID 2842
-
-DATA(insert OID = 2843 (	pg_auth_members	   PGNSP PGUID -1 f c C f t \054 1261 0 0 record_in record_out record_recv record_send - - - d x f 0 -1 0 _null_ _null_ ));
-#define PG_AUTH_MEMBERS_RELTYPE_OID 2843
-
-DATA(insert OID = 6996 (	pg_database	   PGNSP PGUID -1 f c C f t \054 1262 0 0 record_in record_out record_recv record_send - - - d x f 0 -1 0 _null_ _null_ ));
-#define PG_DATABASE_RELTYPE_OID 6996
-
 /* OIDS 100 - 199 */
 DATA(insert OID = 142 ( xml		   PGNSP PGUID -1 f b U f t \054 0 0 143 xml_in xml_out xml_recv xml_send - - - i x f 0 -1 0 _null_ _null_ ));
 DESCR("XML content");

--- a/src/include/catalog/toasting.h
+++ b/src/include/catalog/toasting.h
@@ -51,9 +51,6 @@ DECLARE_TOAST(pg_statistic, 2840, 2841);
 DECLARE_TOAST(pg_trigger, 2336, 2337);
 
 /* shared catalogs */
-DECLARE_TOAST(pg_authid, 7842, 7843);
-#define PgAuthidToastTable 7842
-#define PgAuthidToastIndex 7843
 DECLARE_TOAST(pg_database, 2844, 2845);
 #define PgDatabaseToastTable 2844
 #define PgDatabaseToastIndex 2845

--- a/src/test/regress/input/auth_constraint.source
+++ b/src/test/regress/input/auth_constraint.source
@@ -1,19 +1,19 @@
---- By design, every boolean query (which doesn't error out) in this test must return true.
---- For reference, 2011-08-30 was a Tuesday!
----
+-- By design, every boolean query (which doesn't error out) in this test must return true.
+-- For reference, 2011-08-30 was a Tuesday!
+--
 CREATE FUNCTION check_auth_time_constraints(cstring, timestamptz)
     RETURNS bool
     AS '@abs_builddir@/regress@DLSUFFIX@'
     LANGUAGE C IMMUTABLE STRICT NO SQL;
 
----
---- invalid timestamp should error out
----
+--
+-- invalid timestamp should error out
+--
 SELECT check_auth_time_constraints('abc', '5');
 
----
---- basic day level constraints
----
+--
+-- basic day level constraints
+--
 CREATE ROLE abc DENY DAY 2;
 select c.start_day, c.start_time, c.end_day, c.end_time from pg_authid a, pg_auth_time_constraint c where c.authid = a.oid and a.rolname = 'abc';
 SELECT check_auth_time_constraints('abc', '2011-08-29 23:59:59');
@@ -23,9 +23,9 @@ SELECT NOT check_auth_time_constraints('abc', '2011-08-30 23:59:59');
 SELECT check_auth_time_constraints('abc', '2011-08-31 00:00:00');
 DROP ROLE abc;
 
----
---- basic time level constraints
---- 
+--
+-- basic time level constraints
+--
 CREATE ROLE abc WITH LOGIN DENY DAY 'Saturday';
 DROP ROLE abc;
 CREATE ROLE abc DENY DAY 2 TIME '13:15:34';
@@ -35,9 +35,9 @@ SELECT NOT check_auth_time_constraints('abc', '2011-08-30 13:15:34');
 SELECT check_auth_time_constraints('abc', '2011-08-30 13:15:35');
 DROP ROLE abc;
 
----
---- some similar CREATE ROLE coverage
----
+--
+-- some similar CREATE ROLE coverage
+--
 CREATE ROLE abc DENY BETWEEN DAY 2 AND DAY 3;
 select c.start_day, c.start_time, c.end_day, c.end_time from pg_authid a, pg_auth_time_constraint c where c.authid = a.oid and a.rolname = 'abc';
 SELECT check_auth_time_constraints('abc', '2011-08-29 23:59:59');
@@ -70,9 +70,9 @@ SELECT NOT check_auth_time_constraints('abc', '2011-08-31 11:34:53');
 SELECT check_auth_time_constraints('abc', '2011-08-31 11:34:54');
 DROP ROLE abc;
 
----
---- ALTER ROLE grammar coverage (some repetition here)
----
+--
+-- ALTER ROLE grammar coverage (some repetition here)
+--
 CREATE ROLE abc;
 ALTER ROLE abc DENY DAY 2;
 select c.start_day, c.start_time, c.end_day, c.end_time from pg_authid a, pg_auth_time_constraint c where c.authid = a.oid and a.rolname = 'abc';
@@ -127,9 +127,9 @@ SELECT NOT check_auth_time_constraints('abc', '2011-08-31 11:34:53');
 SELECT check_auth_time_constraints('abc', '2011-08-31 11:34:54');
 DROP ROLE abc;
 
----
---- very minimal coverage of CREATE USER and ALTER USER
----
+--
+-- very minimal coverage of CREATE USER and ALTER USER
+--
 CREATE USER abc DENY DAY 2;
 select c.start_day, c.start_time, c.end_day, c.end_time from pg_authid a, pg_auth_time_constraint c where c.authid = a.oid and a.rolname = 'abc';
 select NOT check_auth_time_constraints('abc', '2011-08-30 12:00:00');
@@ -139,9 +139,9 @@ select NOT check_auth_time_constraints('abc', '2011-08-31 12:00:00');
 ALTER USER abc DROP DENY FOR DAY 2 TIME '12:00:00';
 DROP USER abc;
 
----
---- CREATE ROLE w/ multiple deny specifications
----
+--
+-- CREATE ROLE w/ multiple deny specifications
+--
 CREATE ROLE abc DENY DAY 0 DENY DAY 2 DENY BETWEEN DAY 4 AND DAY 5 TIME '13:00:00';
 select c.start_day, c.start_time, c.end_day, c.end_time from pg_authid a, pg_auth_time_constraint c where c.authid = a.oid and a.rolname = 'abc';
 SELECT check_auth_time_constraints('abc', '2011-08-27 23:59:59');
@@ -158,9 +158,9 @@ SELECT NOT check_auth_time_constraints('abc', '2011-09-02 13:00:00');
 SELECT check_auth_time_constraints('abc', '2011-09-02 13:00:01');
 DROP ROLE abc;
 
----
---- ALTER ROLE w/ multiple deny specifications
----
+--
+-- ALTER ROLE w/ multiple deny specifications
+--
 CREATE ROLE abc;
 ALTER ROLE abc DENY DAY 0 DENY DAY 2 DENY BETWEEN DAY 4 AND DAY 5 TIME '13:00:00';
 select c.start_day, c.start_time, c.end_day, c.end_time from pg_authid a, pg_auth_time_constraint c where c.authid = a.oid and a.rolname = 'abc';
@@ -178,10 +178,10 @@ SELECT NOT check_auth_time_constraints('abc', '2011-09-02 13:00:00');
 SELECT check_auth_time_constraints('abc', '2011-09-02 13:00:01');
 DROP ROLE abc;
 
----
---- ALTER ROLE DROP
---- This syntax drops any rule that *overlaps* with the specified point/interval.
----
+--
+-- ALTER ROLE DROP
+-- This syntax drops any rule that *overlaps* with the specified point/interval.
+--
 CREATE ROLE abc DENY DAY 2;
 select c.start_day, c.start_time, c.end_day, c.end_time from pg_authid a, pg_auth_time_constraint c where c.authid = a.oid and a.rolname = 'abc';
 SELECT NOT check_auth_time_constraints('abc', '2011-08-30 12:00:00');
@@ -207,33 +207,33 @@ ALTER ROLE abc DENY DAY 0 DENY DAY 1;
 ALTER ROLE abc DROP DENY FOR DAY 2;
 DROP ROLE abc;
 
----
---- ALTER ROLE w/ multiple deny and drop specifications
---- This should error out, as the expected behavior isn't quite intuitive.
----
+--
+-- ALTER ROLE w/ multiple deny and drop specifications
+-- This should error out, as the expected behavior isn't quite intuitive.
+--
 CREATE ROLE abc;
 ALTER ROLE abc DENY DAY 0 DENY DAY 1 DENY DAY 2 DROP DENY FOR DAY 1;
 DROP ROLE abc;
 
----
---- DROP ROLE must release associated auth. constraints
----
+--
+-- DROP ROLE must release associated auth. constraints
+--
 CREATE ROLE abc DENY DAY 0 DENY DAY 1 DENY DAY 3 TIME '3:00 PM';
 select c.start_day, c.start_time, c.end_day, c.end_time from pg_authid a, pg_auth_time_constraint c where c.authid = a.oid and a.rolname = 'abc';
 DROP ROLE abc;
 select c.start_day, c.start_time, c.end_day, c.end_time from pg_authid a, pg_auth_time_constraint c where c.authid = a.oid and a.rolname = 'abc';
 
----
---- Wrap-around intervals
----
+--
+-- Wrap-around intervals
+--
 CREATE ROLE abc DENY BETWEEN DAY 6 TIME '12:00:00' AND DAY 0;
 CREATE ROLE abc;
 ALTER ROLE abc DENY BETWEEN DAY 5 AND DAY 1;
 DROP ROLE abc;
 
----
---- English days of week
----
+--
+-- English days of week
+--
 CREATE ROLE abc DENY BETWEEN DAY 'Tuesday' TIME '12:00:00' AND DAY 2 TIME '1:00 PM';
 select c.start_day, c.start_time, c.end_day, c.end_time from pg_authid a, pg_auth_time_constraint c where c.authid = a.oid and a.rolname = 'abc';
 SELECT check_auth_time_constraints('abc', '2011-08-30 11:59:59');
@@ -242,21 +242,21 @@ SELECT NOT check_auth_time_constraints('abc', '2011-08-30 13:00:00');
 SELECT check_auth_time_constraints('abc', '2011-08-30 13:00:01');
 DROP ROLE abc;
 
----
---- English days of week (negative)
----
+--
+-- English days of week (negative)
+--
 CREATE ROLE abc DENY DAY 'Monkey' TIME '12:00:00';
 CREATE ROLE abc WITH LOGIN DENY BETWEEN DAY 'Monday' TIME '00:00' AND DAY 'Monday' TIME '25:00';
 CREATE ROLE abc WITH LOGIN DENY BETWEEN DAY 'Monday' TIME '01:65 AM' AND DAY 'Monday' TIME '12:00 PM';
 CREATE ROLE abc WITH LOGIN DENY BETWEEN DAY 'Monday' TIME '-01:00' AND DAY 'Monday' TIME '06:00 PM';
 CREATE ROLE abc DENY BETWEEN DAY 'Monday' TIME '00:00' AND DAY 'Monday' TIME '25:00';
 
----
---- What is '24:00:00'? Apparently, '2011-08-30 24:00:00' == '2011-08-31 00:00:00'.
---- But interpreted as a sole time value, '24:00:00' != '00:00:00' and
---- '24:00:00' > '23:59:59'. So, the following three queries should evaluate to true.
---- In other words, there is no way for the current time to ever be '24:00:00'.
----
+--
+-- What is '24:00:00'? Apparently, '2011-08-30 24:00:00' == '2011-08-31 00:00:00'.
+-- But interpreted as a sole time value, '24:00:00' != '00:00:00' and
+-- '24:00:00' > '23:59:59'. So, the following three queries should evaluate to true.
+-- In other words, there is no way for the current time to ever be '24:00:00'.
+--
 CREATE ROLE abc DENY DAY 2 TIME '24:00:00';
 select c.start_day, c.start_time, c.end_day, c.end_time from pg_authid a, pg_auth_time_constraint c where c.authid = a.oid and a.rolname = 'abc';
 SELECT check_auth_time_constraints('abc', '2011-08-30 23:59:59');
@@ -265,9 +265,9 @@ SELECT check_auth_time_constraints('abc', '2011-08-31 00:00:00');
 DROP ROLE abc;
 
 
----
---- Inheritance of time constraints (negative)
----
+--
+-- Inheritance of time constraints (negative)
+--
 CREATE ROLE abc DENY BETWEEN DAY 0 AND DAY 6;
 SELECT NOT check_auth_time_constraints('abc', '2011-08-31 12:00:00');
 CREATE ROLE foo IN ROLE abc;
@@ -275,9 +275,9 @@ SELECT check_auth_time_constraints('foo', '2011-08-31 12:00:00');
 DROP ROLE foo;
 DROP ROLE abc;
 
----
---- Exercise catalog DML and pg_auth_time_constraint trigger
----
+--
+-- Exercise catalog DML and pg_auth_time_constraint trigger
+--
 SET allow_system_table_mods = dml;
 CREATE ROLE abc;
 insert into pg_auth_time_constraint (select oid, 2, '12:00:00', 3, '12:00:00' from pg_authid where rolname = 'abc');
@@ -300,9 +300,9 @@ SELECT check_auth_time_constraints('abc', '2011-08-31 00:00:00');
 DROP ROLE abc;
 RESET allow_system_table_mods;
 
----
---- Superuser testing across CREATE ROLE, ALTER ROLE, and trigger
----
+--
+-- Superuser testing across CREATE ROLE, ALTER ROLE, and trigger
+--
 
 create role abc with login nosuperuser nocreaterole;
 drop role abc;

--- a/src/test/regress/output/auth_constraint.source
+++ b/src/test/regress/output/auth_constraint.source
@@ -1,20 +1,20 @@
---- By design, every boolean query (which doesn't error out) in this test must return true.
---- For reference, 2011-08-30 was a Tuesday!
----
+-- By design, every boolean query (which doesn't error out) in this test must return true.
+-- For reference, 2011-08-30 was a Tuesday!
+--
 CREATE FUNCTION check_auth_time_constraints(cstring, timestamptz)
     RETURNS bool
     AS '@abs_builddir@/regress@DLSUFFIX@'
     LANGUAGE C IMMUTABLE STRICT NO SQL;
----
---- invalid timestamp should error out
----
+--
+-- invalid timestamp should error out
+--
 SELECT check_auth_time_constraints('abc', '5');
 ERROR:  invalid input syntax for type timestamp with time zone: "5"
 LINE 1: SELECT check_auth_time_constraints('abc', '5');
                                                   ^
----
---- basic day level constraints
----
+--
+-- basic day level constraints
+--
 CREATE ROLE abc DENY DAY 2;
 NOTICE:  resource queue required -- using default resource queue "pg_default"
 select c.start_day, c.start_time, c.end_day, c.end_time from pg_authid a, pg_auth_time_constraint c where c.authid = a.oid and a.rolname = 'abc';
@@ -54,9 +54,9 @@ SELECT check_auth_time_constraints('abc', '2011-08-31 00:00:00');
 (1 row)
 
 DROP ROLE abc;
----
---- basic time level constraints
---- 
+--
+-- basic time level constraints
+--
 CREATE ROLE abc WITH LOGIN DENY DAY 'Saturday';
 NOTICE:  resource queue required -- using default resource queue "pg_default"
 DROP ROLE abc;
@@ -87,9 +87,9 @@ SELECT check_auth_time_constraints('abc', '2011-08-30 13:15:35');
 (1 row)
 
 DROP ROLE abc;
----
---- some similar CREATE ROLE coverage
----
+--
+-- some similar CREATE ROLE coverage
+--
 CREATE ROLE abc DENY BETWEEN DAY 2 AND DAY 3;
 NOTICE:  resource queue required -- using default resource queue "pg_default"
 select c.start_day, c.start_time, c.end_day, c.end_time from pg_authid a, pg_auth_time_constraint c where c.authid = a.oid and a.rolname = 'abc';
@@ -222,9 +222,9 @@ SELECT check_auth_time_constraints('abc', '2011-08-31 11:34:54');
 (1 row)
 
 DROP ROLE abc;
----
---- ALTER ROLE grammar coverage (some repetition here)
----
+--
+-- ALTER ROLE grammar coverage (some repetition here)
+--
 CREATE ROLE abc;
 NOTICE:  resource queue required -- using default resource queue "pg_default"
 ALTER ROLE abc DENY DAY 2;
@@ -429,9 +429,9 @@ SELECT check_auth_time_constraints('abc', '2011-08-31 11:34:54');
 (1 row)
 
 DROP ROLE abc;
----
---- very minimal coverage of CREATE USER and ALTER USER
----
+--
+-- very minimal coverage of CREATE USER and ALTER USER
+--
 CREATE USER abc DENY DAY 2;
 NOTICE:  resource queue required -- using default resource queue "pg_default"
 select c.start_day, c.start_time, c.end_day, c.end_time from pg_authid a, pg_auth_time_constraint c where c.authid = a.oid and a.rolname = 'abc';
@@ -463,9 +463,9 @@ select NOT check_auth_time_constraints('abc', '2011-08-31 12:00:00');
 ALTER USER abc DROP DENY FOR DAY 2 TIME '12:00:00';
 NOTICE:  dropping DENY rule for "abc" between Tuesday 00:00:00 and Tuesday 24:00:00
 DROP USER abc;
----
---- CREATE ROLE w/ multiple deny specifications
----
+--
+-- CREATE ROLE w/ multiple deny specifications
+--
 CREATE ROLE abc DENY DAY 0 DENY DAY 2 DENY BETWEEN DAY 4 AND DAY 5 TIME '13:00:00';
 NOTICE:  resource queue required -- using default resource queue "pg_default"
 select c.start_day, c.start_time, c.end_day, c.end_time from pg_authid a, pg_auth_time_constraint c where c.authid = a.oid and a.rolname = 'abc';
@@ -549,9 +549,9 @@ SELECT check_auth_time_constraints('abc', '2011-09-02 13:00:01');
 (1 row)
 
 DROP ROLE abc;
----
---- ALTER ROLE w/ multiple deny specifications
----
+--
+-- ALTER ROLE w/ multiple deny specifications
+--
 CREATE ROLE abc;
 NOTICE:  resource queue required -- using default resource queue "pg_default"
 ALTER ROLE abc DENY DAY 0 DENY DAY 2 DENY BETWEEN DAY 4 AND DAY 5 TIME '13:00:00';
@@ -636,10 +636,10 @@ SELECT check_auth_time_constraints('abc', '2011-09-02 13:00:01');
 (1 row)
 
 DROP ROLE abc;
----
---- ALTER ROLE DROP
---- This syntax drops any rule that *overlaps* with the specified point/interval.
----
+--
+-- ALTER ROLE DROP
+-- This syntax drops any rule that *overlaps* with the specified point/interval.
+--
 CREATE ROLE abc DENY DAY 2;
 NOTICE:  resource queue required -- using default resource queue "pg_default"
 select c.start_day, c.start_time, c.end_day, c.end_time from pg_authid a, pg_auth_time_constraint c where c.authid = a.oid and a.rolname = 'abc';
@@ -718,19 +718,19 @@ ALTER ROLE abc DENY DAY 0 DENY DAY 1;
 ALTER ROLE abc DROP DENY FOR DAY 2;
 ERROR:  cannot find matching DENY rules for "abc"
 DROP ROLE abc;
----
---- ALTER ROLE w/ multiple deny and drop specifications
---- This should error out, as the expected behavior isn't quite intuitive.
----
+--
+-- ALTER ROLE w/ multiple deny and drop specifications
+-- This should error out, as the expected behavior isn't quite intuitive.
+--
 CREATE ROLE abc;
 NOTICE:  resource queue required -- using default resource queue "pg_default"
 ALTER ROLE abc DENY DAY 0 DENY DAY 1 DENY DAY 2 DROP DENY FOR DAY 1;
 ERROR:  conflicting or redundant options
 HINT:  DENY and DROP DENY cannot be used in the same ALTER ROLE statement.
 DROP ROLE abc;
----
---- DROP ROLE must release associated auth. constraints
----
+--
+-- DROP ROLE must release associated auth. constraints
+--
 CREATE ROLE abc DENY DAY 0 DENY DAY 1 DENY DAY 3 TIME '3:00 PM';
 NOTICE:  resource queue required -- using default resource queue "pg_default"
 select c.start_day, c.start_time, c.end_day, c.end_time from pg_authid a, pg_auth_time_constraint c where c.authid = a.oid and a.rolname = 'abc';
@@ -747,9 +747,9 @@ select c.start_day, c.start_time, c.end_day, c.end_time from pg_authid a, pg_aut
 -----------+------------+---------+----------
 (0 rows)
 
----
---- Wrap-around intervals
----
+--
+-- Wrap-around intervals
+--
 CREATE ROLE abc DENY BETWEEN DAY 6 TIME '12:00:00' AND DAY 0;
 ERROR:  time interval must not wrap around
 CREATE ROLE abc;
@@ -757,9 +757,9 @@ NOTICE:  resource queue required -- using default resource queue "pg_default"
 ALTER ROLE abc DENY BETWEEN DAY 5 AND DAY 1;
 ERROR:  time interval must not wrap around
 DROP ROLE abc;
----
---- English days of week
----
+--
+-- English days of week
+--
 CREATE ROLE abc DENY BETWEEN DAY 'Tuesday' TIME '12:00:00' AND DAY 2 TIME '1:00 PM';
 NOTICE:  resource queue required -- using default resource queue "pg_default"
 select c.start_day, c.start_time, c.end_day, c.end_time from pg_authid a, pg_auth_time_constraint c where c.authid = a.oid and a.rolname = 'abc';
@@ -793,9 +793,9 @@ SELECT check_auth_time_constraints('abc', '2011-08-30 13:00:01');
 (1 row)
 
 DROP ROLE abc;
----
---- English days of week (negative)
----
+--
+-- English days of week (negative)
+--
 CREATE ROLE abc DENY DAY 'Monkey' TIME '12:00:00';
 ERROR:  invalid weekday name "Monkey"
 HINT:  Day of week must be one of 'Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'.
@@ -807,12 +807,12 @@ CREATE ROLE abc WITH LOGIN DENY BETWEEN DAY 'Monday' TIME '-01:00' AND DAY 'Mond
 ERROR:  invalid input syntax for type time: "-01:00"
 CREATE ROLE abc DENY BETWEEN DAY 'Monday' TIME '00:00' AND DAY 'Monday' TIME '25:00';
 ERROR:  date/time field value out of range: "25:00"
----
---- What is '24:00:00'? Apparently, '2011-08-30 24:00:00' == '2011-08-31 00:00:00'.
---- But interpreted as a sole time value, '24:00:00' != '00:00:00' and
---- '24:00:00' > '23:59:59'. So, the following three queries should evaluate to true.
---- In other words, there is no way for the current time to ever be '24:00:00'.
----
+--
+-- What is '24:00:00'? Apparently, '2011-08-30 24:00:00' == '2011-08-31 00:00:00'.
+-- But interpreted as a sole time value, '24:00:00' != '00:00:00' and
+-- '24:00:00' > '23:59:59'. So, the following three queries should evaluate to true.
+-- In other words, there is no way for the current time to ever be '24:00:00'.
+--
 CREATE ROLE abc DENY DAY 2 TIME '24:00:00';
 NOTICE:  resource queue required -- using default resource queue "pg_default"
 select c.start_day, c.start_time, c.end_day, c.end_time from pg_authid a, pg_auth_time_constraint c where c.authid = a.oid and a.rolname = 'abc';
@@ -840,9 +840,9 @@ SELECT check_auth_time_constraints('abc', '2011-08-31 00:00:00');
 (1 row)
 
 DROP ROLE abc;
----
---- Inheritance of time constraints (negative)
----
+--
+-- Inheritance of time constraints (negative)
+--
 CREATE ROLE abc DENY BETWEEN DAY 0 AND DAY 6;
 NOTICE:  resource queue required -- using default resource queue "pg_default"
 SELECT NOT check_auth_time_constraints('abc', '2011-08-31 12:00:00');
@@ -861,9 +861,9 @@ SELECT check_auth_time_constraints('foo', '2011-08-31 12:00:00');
 
 DROP ROLE foo;
 DROP ROLE abc;
----
---- Exercise catalog DML and pg_auth_time_constraint trigger
----
+--
+-- Exercise catalog DML and pg_auth_time_constraint trigger
+--
 SET allow_system_table_mods = dml;
 CREATE ROLE abc;
 NOTICE:  resource queue required -- using default resource queue "pg_default"
@@ -943,9 +943,9 @@ SELECT check_auth_time_constraints('abc', '2011-08-31 00:00:00');
 
 DROP ROLE abc;
 RESET allow_system_table_mods;
----
---- Superuser testing across CREATE ROLE, ALTER ROLE, and trigger
----
+--
+-- Superuser testing across CREATE ROLE, ALTER ROLE, and trigger
+--
 create role abc with login nosuperuser nocreaterole;
 NOTICE:  resource queue required -- using default resource queue "pg_default"
 drop role abc;

--- a/src/test/regress/regress_gp.c
+++ b/src/test/regress/regress_gp.c
@@ -1097,18 +1097,6 @@ check_auth_time_constraints(PG_FUNCTION_ARGS)
 	char		   *rolname = PG_GETARG_CSTRING(0);
 	TimestampTz 	timestamp = PG_GETARG_TIMESTAMPTZ(1);
 
-	/*
-	 * For the sake of unit testing, we must ensure that the role information
-	 * is accessible to the backend process. This function call will ensure the
-	 * role information is reloaded. This is a moot point for the traditional
-	 * auth. checking where this data already resides in the PostmasterContext.
-	 * For more information, see force_load_role().
-	 *
-	 * GPDB_90_MERGE_FIXME: IIUC this should no longer be needed once we rewrite
-	 * the auth_time_constraints logic. Commenting for now to get things
-	 * building.
-	 */
-	/* force_load_role(); */
 	PG_RETURN_BOOL(check_auth_time_constraints_internal(rolname, timestamp));
 }
 


### PR DESCRIPTION
Now that flat files are gone, we need to walk `pg_auth_time_constraint` directly when checking time-based authorization. To do that we need to be able to access that relation during client authentication, which takes a little bit of doing.

Commit 35dbaa3 is the meat of the change; it does all the heavy lifting with the catalog.