### PR TITLE
Disable two-phase commit for heap vacuum

### DIFF
--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -3975,6 +3975,7 @@ _copyVacuumStmt(VacuumStmt *from)
 	COPY_NODE_FIELD(relation);
 	COPY_NODE_FIELD(va_cols);
 
+	COPY_SCALAR_FIELD(skip_twophase);
 	COPY_NODE_FIELD(expanded_relids);
 	COPY_NODE_FIELD(appendonly_compaction_segno);
 	COPY_NODE_FIELD(appendonly_compaction_insert_segno);

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -4156,6 +4156,7 @@ _outVacuumStmt(StringInfo str, VacuumStmt *node)
 	WRITE_NODE_FIELD(relation);
 	WRITE_NODE_FIELD(va_cols);
 
+	WRITE_BOOL_FIELD(skip_twophase);
 	WRITE_NODE_FIELD(expanded_relids);
 	WRITE_NODE_FIELD(appendonly_compaction_segno);
 	WRITE_NODE_FIELD(appendonly_compaction_insert_segno);

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -2744,6 +2744,7 @@ _readVacuumStmt(void)
 	READ_NODE_FIELD(relation);
 	READ_NODE_FIELD(va_cols);
 
+	READ_BOOL_FIELD(skip_twophase);
 	READ_NODE_FIELD(expanded_relids);
 	READ_NODE_FIELD(appendonly_compaction_segno);
 	READ_NODE_FIELD(appendonly_compaction_insert_segno);

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -2819,6 +2819,7 @@ typedef struct VacuumStmt
 	/* Object IDs for relations which expand from partition definitions */
 	List	   *expanded_relids;
 
+	bool skip_twophase;
 	/*
 	 * AO segment file num to compact (integer).
 	 */


### PR DESCRIPTION
This commit is an attempt to liberate VACUUM from two phase
commit. During VACUUM, we do not actually write transaction ids to
anything, or make any other logical changes to tables, so it should be
safe to run VACUUM without a two-phase commit.

The merge with Postgres 9.0 has brought in the concept of 'relmapped'
tables. Tables like 'pg_class' are used to point to the relfilenodes
that contain any given relation, but this is problematic when trying
to swap out the relfile node of 'pg_class' itself.  The merge has also
brought in the use CLUSTER for VACUUM FULL. If you try to run VACUUM
FULL on 'pg_class', the relfile itself is swapped when it is vacuumed,
and the relmap is updated with a pointer to the new version of the
table. Postgres doesn't actually support PREPARE for changes to the
relmap, so instead of adding support for it in Greenplum, we have
opted to disable two-phase commit for VACUUM on heap tables.