### PR TITLE
Disable two-phase commit for REINDEX

### DIFF
--- a/src/backend/commands/indexcmds.c
+++ b/src/backend/commands/indexcmds.c
@@ -1863,8 +1863,7 @@ ReindexIndex(ReindexStmt *stmt)
 	{
 		CdbDispatchUtilityStatement((Node *) stmt,
 									DF_CANCEL_ON_ERROR |
-									DF_WITH_SNAPSHOT |
-									DF_NEED_TWO_PHASE,
+									DF_WITH_SNAPSHOT,
 									GetAssignedOidsForDispatch(),
 									NULL);
 	}
@@ -1926,8 +1925,7 @@ ReindexRelationList(List *relids)
 			else if (Gp_role == GP_ROLE_DISPATCH)
 				CdbDispatchUtilityStatement((Node *) stmt,
 											DF_CANCEL_ON_ERROR |
-											DF_WITH_SNAPSHOT |
-											DF_NEED_TWO_PHASE,
+											DF_WITH_SNAPSHOT,
 											GetAssignedOidsForDispatch(), /* FIXME */
 											NULL);
 


### PR DESCRIPTION
Because relmapped relations do not support PREPARE, reindexing
relmapped relations such as 'pg_class' fail with two-phase
commit. Reindex should not make any logical changes to table data, and
therefore should not be a problem if it fails on one or more
segments. Two-phase commit was initially turned on with REINDEX
because it was a requirement of the database at that time to keep the
relfilenode in sync on all segments. This is no longer a requirement
of Greenplum, so we are now able disable two-phase commit for the
REINDEX operation.