### PR TITLE
Fix analyze regress test failure.

### DIFF
--- a/src/backend/commands/analyze.c
+++ b/src/backend/commands/analyze.c
@@ -280,8 +280,11 @@ analyze_rel_internal(Oid relid, VacuumStmt *vacstmt,
 
 	/*
 	 * Do the normal non-recursive ANALYZE.
+	 * Just skip this for partitioned tables, which don't contain any rows.
 	 */
-	do_analyze_rel(onerel, vacstmt, false, false);
+	PartStatus ps = rel_part_status(relid);
+	if (!(ps == PART_STATUS_ROOT || ps == PART_STATUS_INTERIOR))
+		do_analyze_rel(onerel, vacstmt, false, false);
 
 	/*
 	 * If there are child tables, do recursive ANALYZE.

--- a/src/test/regress/expected/analyze.out
+++ b/src/test/regress/expected/analyze.out
@@ -26,7 +26,7 @@ analyze p3_sales;
 select relname, reltuples, relpages from pg_class where relname like 'p3_sales%' order by relname;
                              relname                             | reltuples | relpages 
 -----------------------------------------------------------------+-----------+----------
- p3_sales                                                        |         0 |        1
+ p3_sales                                                        |         0 |        0
  p3_sales_1_prt_2                                                |         0 |        0
  p3_sales_1_prt_2_2_prt_2                                        |         0 |        0
  p3_sales_1_prt_2_2_prt_2_3_prt_other_regions                    |         0 |        1
@@ -44,13 +44,13 @@ select relname, reltuples, relpages from pg_class where relname like 'p3_sales%'
 (15 rows)
 
 select * from pg_stats where tablename like 'p3_sales%' order by tablename, attname;
- schemaname |             tablename              | attname | null_frac | avg_width | n_distinct | most_common_vals | most_common_freqs | histogram_bounds | correlation 
-------------+------------------------------------+---------+-----------+-----------+------------+------------------+-------------------+------------------+-------------
- public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | day     |         0 |         4 |       -0.5 | {20}             | {1}               |                  |           1
- public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | id      |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
- public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | month   |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
- public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | region  |         0 |         4 |       -0.5 | {usa}            | {1}               |                  |           1
- public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | year    |         0 |         4 |       -0.5 | {2002}           | {1}               |                  |           1
+ schemaname |             tablename              | attname | inherited | null_frac | avg_width | n_distinct | most_common_vals | most_common_freqs | histogram_bounds | correlation 
+------------+------------------------------------+---------+-----------+-----------+-----------+------------+------------------+-------------------+------------------+-------------
+ public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | day     | f         |         0 |         4 |       -0.5 | {20}             | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | id      | f         |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | month   | f         |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | region  | f         |         0 |         4 |       -0.5 | {usa}            | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | year    | f         |         0 |         4 |       -0.5 | {2002}           | {1}               |                  |           1
 (5 rows)
 
 -- Case 2: Analyzing a midlevel partition directly should give a WARNING message and should not update any stats for the table.
@@ -96,8 +96,8 @@ select relname, reltuples, relpages from pg_class where relname like 'p3_sales%'
 (15 rows)
 
 select * from pg_stats where tablename like 'p3_sales%' order by tablename, attname;
- schemaname | tablename | attname | null_frac | avg_width | n_distinct | most_common_vals | most_common_freqs | histogram_bounds | correlation 
-------------+-----------+---------+-----------+-----------+------------+------------------+-------------------+------------------+-------------
+ schemaname | tablename | attname | inherited | null_frac | avg_width | n_distinct | most_common_vals | most_common_freqs | histogram_bounds | correlation 
+------------+-----------+---------+-----------+-----------+-----------+------------+------------------+-------------------+------------------+-------------
 (0 rows)
 
 -- Case 3: Analyzing leaf table directly should update the stats only for itself
@@ -142,13 +142,13 @@ select relname, reltuples, relpages from pg_class where relname like 'p3_sales%'
 (15 rows)
 
 select * from pg_stats where tablename like 'p3_sales%' order by tablename, attname;
- schemaname |             tablename              | attname | null_frac | avg_width | n_distinct | most_common_vals | most_common_freqs | histogram_bounds | correlation 
-------------+------------------------------------+---------+-----------+-----------+------------+------------------+-------------------+------------------+-------------
- public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | day     |         0 |         4 |       -0.5 | {20}             | {1}               |                  |           1
- public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | id      |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
- public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | month   |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
- public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | region  |         0 |         4 |       -0.5 | {usa}            | {1}               |                  |           1
- public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | year    |         0 |         4 |       -0.5 | {2002}           | {1}               |                  |           1
+ schemaname |             tablename              | attname | inherited | null_frac | avg_width | n_distinct | most_common_vals | most_common_freqs | histogram_bounds | correlation 
+------------+------------------------------------+---------+-----------+-----------+-----------+------------+------------------+-------------------+------------------+-------------
+ public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | day     | f         |         0 |         4 |       -0.5 | {20}             | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | id      | f         |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | month   | f         |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | region  | f         |         0 |         4 |       -0.5 | {usa}            | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | year    | f         |         0 |         4 |       -0.5 | {2002}           | {1}               |                  |           1
 (5 rows)
 
 -- Case 4: Analyzing the database with the GUC optimizer_analyze_root_partition and optimizer_analyze_midlevel_partition set to OFF should only update stats for leaf partition tables
@@ -175,7 +175,7 @@ analyze;
 select relname, reltuples, relpages from pg_class where relname like 'p3_sales%' order by relname;
                              relname                             | reltuples | relpages 
 -----------------------------------------------------------------+-----------+----------
- p3_sales                                                        |         0 |        1
+ p3_sales                                                        |         0 |        0
  p3_sales_1_prt_2                                                |         0 |        0
  p3_sales_1_prt_2_2_prt_2                                        |         0 |        0
  p3_sales_1_prt_2_2_prt_2_3_prt_other_regions                    |         0 |        1
@@ -193,13 +193,13 @@ select relname, reltuples, relpages from pg_class where relname like 'p3_sales%'
 (15 rows)
 
 select * from pg_stats where tablename like 'p3_sales%' order by tablename, attname;
- schemaname |             tablename              | attname | null_frac | avg_width | n_distinct | most_common_vals | most_common_freqs | histogram_bounds | correlation 
-------------+------------------------------------+---------+-----------+-----------+------------+------------------+-------------------+------------------+-------------
- public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | day     |         0 |         4 |       -0.5 | {20}             | {1}               |                  |           1
- public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | id      |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
- public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | month   |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
- public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | region  |         0 |         4 |       -0.5 | {usa}            | {1}               |                  |           1
- public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | year    |         0 |         4 |       -0.5 | {2002}           | {1}               |                  |           1
+ schemaname |             tablename              | attname | inherited | null_frac | avg_width | n_distinct | most_common_vals | most_common_freqs | histogram_bounds | correlation 
+------------+------------------------------------+---------+-----------+-----------+-----------+------------+------------------+-------------------+------------------+-------------
+ public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | day     | f         |         0 |         4 |       -0.5 | {20}             | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | id      | f         |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | month   | f         |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | region  | f         |         0 |         4 |       -0.5 | {usa}            | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | year    | f         |         0 |         4 |       -0.5 | {2002}           | {1}               |                  |           1
 (5 rows)
 
 -- Case 5: Vacuum analyzing the database should vacuum all the tables for p3_sales and should only update the stats for all leaf partitions of p3_sales
@@ -226,7 +226,7 @@ vacuum analyze;
 select relname, reltuples, relpages from pg_class where relname like 'p3_sales%' order by relname;
                              relname                             | reltuples | relpages 
 -----------------------------------------------------------------+-----------+----------
- p3_sales                                                        |         0 |        1
+ p3_sales                                                        |         0 |        0
  p3_sales_1_prt_2                                                |         0 |        0
  p3_sales_1_prt_2_2_prt_2                                        |         0 |        0
  p3_sales_1_prt_2_2_prt_2_3_prt_other_regions                    |         0 |        1
@@ -244,13 +244,13 @@ select relname, reltuples, relpages from pg_class where relname like 'p3_sales%'
 (15 rows)
 
 select * from pg_stats where tablename like 'p3_sales%' order by tablename, attname;
- schemaname |             tablename              | attname | null_frac | avg_width | n_distinct | most_common_vals | most_common_freqs | histogram_bounds | correlation 
-------------+------------------------------------+---------+-----------+-----------+------------+------------------+-------------------+------------------+-------------
- public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | day     |         0 |         4 |       -0.5 | {20}             | {1}               |                  |           1
- public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | id      |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
- public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | month   |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
- public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | region  |         0 |         4 |       -0.5 | {usa}            | {1}               |                  |           1
- public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | year    |         0 |         4 |       -0.5 | {2002}           | {1}               |                  |           1
+ schemaname |             tablename              | attname | inherited | null_frac | avg_width | n_distinct | most_common_vals | most_common_freqs | histogram_bounds | correlation 
+------------+------------------------------------+---------+-----------+-----------+-----------+------------+------------------+-------------------+------------------+-------------
+ public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | day     | f         |         0 |         4 |       -0.5 | {20}             | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | id      | f         |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | month   | f         |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | region  | f         |         0 |         4 |       -0.5 | {usa}            | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | year    | f         |         0 |         4 |       -0.5 | {2002}           | {1}               |                  |           1
 (5 rows)
 
 select count(*) from pg_stat_last_operation pgl, pg_class pgc where pgl.objid=pgc.oid and pgc.relname like 'p3_sales%';
@@ -283,7 +283,7 @@ analyze rootpartition p3_sales;
 select relname, reltuples, relpages from pg_class where relname like 'p3_sales%' order by relname;
                              relname                             | reltuples | relpages 
 -----------------------------------------------------------------+-----------+----------
- p3_sales                                                        |         2 |        1
+ p3_sales                                                        |         0 |        0
  p3_sales_1_prt_2                                                |         0 |        0
  p3_sales_1_prt_2_2_prt_2                                        |         0 |        0
  p3_sales_1_prt_2_2_prt_2_3_prt_other_regions                    |         0 |        0
@@ -301,13 +301,13 @@ select relname, reltuples, relpages from pg_class where relname like 'p3_sales%'
 (15 rows)
 
 select * from pg_stats where tablename like 'p3_sales%' order by tablename, attname;
- schemaname | tablename | attname | null_frac | avg_width | n_distinct | most_common_vals | most_common_freqs | histogram_bounds | correlation 
-------------+-----------+---------+-----------+-----------+------------+------------------+-------------------+------------------+-------------
- public     | p3_sales  | day     |         0 |         4 |       -0.5 | {20}             | {1}               |                  |           1
- public     | p3_sales  | id      |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
- public     | p3_sales  | month   |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
- public     | p3_sales  | region  |         0 |         4 |       -0.5 | {usa}            | {1}               |                  |           1
- public     | p3_sales  | year    |         0 |         4 |       -0.5 | {2002}           | {1}               |                  |           1
+ schemaname | tablename | attname | inherited | null_frac | avg_width | n_distinct | most_common_vals | most_common_freqs | histogram_bounds | correlation 
+------------+-----------+---------+-----------+-----------+-----------+------------+------------------+-------------------+------------------+-------------
+ public     | p3_sales  | day     | t         |         0 |         4 |       -0.5 | {20}             | {1}               |                  |           1
+ public     | p3_sales  | id      | t         |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
+ public     | p3_sales  | month   | t         |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
+ public     | p3_sales  | region  | t         |         0 |         4 |       -0.5 | {usa}            | {1}               |                  |           1
+ public     | p3_sales  | year    | t         |         0 |         4 |       -0.5 | {2002}           | {1}               |                  |           1
 (5 rows)
 
 -- Case 7: Analyzing a midlevel partition should give a warning if using ROOTPARTITION keyword and should not update any stats.
@@ -353,8 +353,8 @@ select relname, reltuples, relpages from pg_class where relname like 'p3_sales%'
 (15 rows)
 
 select * from pg_stats where tablename like 'p3_sales%' order by tablename, attname;
- schemaname | tablename | attname | null_frac | avg_width | n_distinct | most_common_vals | most_common_freqs | histogram_bounds | correlation 
-------------+-----------+---------+-----------+-----------+------------+------------------+-------------------+------------------+-------------
+ schemaname | tablename | attname | inherited | null_frac | avg_width | n_distinct | most_common_vals | most_common_freqs | histogram_bounds | correlation 
+------------+-----------+---------+-----------+-----------+-----------+------------+------------------+-------------------+------------------+-------------
 (0 rows)
 
 -- Case 8: Analyzing a leaf partition should give a warning if using ROOTPARTITION keyword and should not update any stats.
@@ -400,8 +400,8 @@ select relname, reltuples, relpages from pg_class where relname like 'p3_sales%'
 (15 rows)
 
 select * from pg_stats where tablename like 'p3_sales%' order by tablename, attname;
- schemaname | tablename | attname | null_frac | avg_width | n_distinct | most_common_vals | most_common_freqs | histogram_bounds | correlation 
-------------+-----------+---------+-----------+-----------+------------+------------------+-------------------+------------------+-------------
+ schemaname | tablename | attname | inherited | null_frac | avg_width | n_distinct | most_common_vals | most_common_freqs | histogram_bounds | correlation 
+------------+-----------+---------+-----------+-----------+-----------+------------+------------------+-------------------+------------------+-------------
 (0 rows)
 
 -- Case 9: Analyzing root table with GUC optimizer_analyze_root_partition set to ON and GUC optimizer_analyze_midlevel_partition set to off should update the leaf table and the root table stats.
@@ -428,7 +428,7 @@ analyze p3_sales;
 select relname, reltuples, relpages from pg_class where relname like 'p3_sales%' order by relname;
                              relname                             | reltuples | relpages 
 -----------------------------------------------------------------+-----------+----------
- p3_sales                                                        |         2 |        1
+ p3_sales                                                        |         0 |        0
  p3_sales_1_prt_2                                                |         0 |        0
  p3_sales_1_prt_2_2_prt_2                                        |         0 |        0
  p3_sales_1_prt_2_2_prt_2_3_prt_other_regions                    |         0 |        1
@@ -446,18 +446,18 @@ select relname, reltuples, relpages from pg_class where relname like 'p3_sales%'
 (15 rows)
 
 select * from pg_stats where tablename like 'p3_sales%' order by tablename, attname;
- schemaname |             tablename              | attname | null_frac | avg_width | n_distinct | most_common_vals | most_common_freqs | histogram_bounds | correlation 
-------------+------------------------------------+---------+-----------+-----------+------------+------------------+-------------------+------------------+-------------
- public     | p3_sales                           | day     |         0 |         4 |       -0.5 | {20}             | {1}               |                  |           1
- public     | p3_sales                           | id      |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
- public     | p3_sales                           | month   |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
- public     | p3_sales                           | region  |         0 |         4 |       -0.5 | {usa}            | {1}               |                  |           1
- public     | p3_sales                           | year    |         0 |         4 |       -0.5 | {2002}           | {1}               |                  |           1
- public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | day     |         0 |         4 |       -0.5 | {20}             | {1}               |                  |           1
- public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | id      |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
- public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | month   |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
- public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | region  |         0 |         4 |       -0.5 | {usa}            | {1}               |                  |           1
- public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | year    |         0 |         4 |       -0.5 | {2002}           | {1}               |                  |           1
+ schemaname |             tablename              | attname | inherited | null_frac | avg_width | n_distinct | most_common_vals | most_common_freqs | histogram_bounds | correlation 
+------------+------------------------------------+---------+-----------+-----------+-----------+------------+------------------+-------------------+------------------+-------------
+ public     | p3_sales                           | day     | t         |         0 |         4 |       -0.5 | {20}             | {1}               |                  |           1
+ public     | p3_sales                           | id      | t         |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
+ public     | p3_sales                           | month   | t         |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
+ public     | p3_sales                           | region  | t         |         0 |         4 |       -0.5 | {usa}            | {1}               |                  |           1
+ public     | p3_sales                           | year    | t         |         0 |         4 |       -0.5 | {2002}           | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | day     | f         |         0 |         4 |       -0.5 | {20}             | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | id      | f         |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | month   | f         |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | region  | f         |         0 |         4 |       -0.5 | {usa}            | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | year    | f         |         0 |         4 |       -0.5 | {2002}           | {1}               |                  |           1
 (10 rows)
 
 -- Case 10: Analyzing root table using ROOTPARTITION keyword with GUC optimizer_analyze_root_partition set to ON and GUC optimizer_analyze_midlevel_partition set to off should update the root table stats only.
@@ -484,7 +484,7 @@ analyze rootpartition p3_sales;
 select relname, reltuples, relpages from pg_class where relname like 'p3_sales%' order by relname;
                              relname                             | reltuples | relpages 
 -----------------------------------------------------------------+-----------+----------
- p3_sales                                                        |         2 |        1
+ p3_sales                                                        |         0 |        0
  p3_sales_1_prt_2                                                |         0 |        0
  p3_sales_1_prt_2_2_prt_2                                        |         0 |        0
  p3_sales_1_prt_2_2_prt_2_3_prt_other_regions                    |         0 |        0
@@ -502,13 +502,13 @@ select relname, reltuples, relpages from pg_class where relname like 'p3_sales%'
 (15 rows)
 
 select * from pg_stats where tablename like 'p3_sales%' order by tablename, attname;
- schemaname | tablename | attname | null_frac | avg_width | n_distinct | most_common_vals | most_common_freqs | histogram_bounds | correlation 
-------------+-----------+---------+-----------+-----------+------------+------------------+-------------------+------------------+-------------
- public     | p3_sales  | day     |         0 |         4 |       -0.5 | {20}             | {1}               |                  |           1
- public     | p3_sales  | id      |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
- public     | p3_sales  | month   |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
- public     | p3_sales  | region  |         0 |         4 |       -0.5 | {usa}            | {1}               |                  |           1
- public     | p3_sales  | year    |         0 |         4 |       -0.5 | {2002}           | {1}               |                  |           1
+ schemaname | tablename | attname | inherited | null_frac | avg_width | n_distinct | most_common_vals | most_common_freqs | histogram_bounds | correlation 
+------------+-----------+---------+-----------+-----------+-----------+------------+------------------+-------------------+------------------+-------------
+ public     | p3_sales  | day     | t         |         0 |         4 |       -0.5 | {20}             | {1}               |                  |           1
+ public     | p3_sales  | id      | t         |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
+ public     | p3_sales  | month   | t         |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
+ public     | p3_sales  | region  | t         |         0 |         4 |       -0.5 | {usa}            | {1}               |                  |           1
+ public     | p3_sales  | year    | t         |         0 |         4 |       -0.5 | {2002}           | {1}               |                  |           1
 (5 rows)
 
 -- Case 11: Analyzing root table with GUC optimizer_analyze_root_partition and optimizer_analyze_midlevel_partition set to ON should update the stats for root, midlevel and leaf partitions.
@@ -535,46 +535,46 @@ analyze p3_sales;
 select relname, reltuples, relpages from pg_class where relname like 'p3_sales%' order by relname;
                              relname                             | reltuples | relpages 
 -----------------------------------------------------------------+-----------+----------
- p3_sales                                                        |         2 |        1
- p3_sales_1_prt_2                                                |         2 |        1
- p3_sales_1_prt_2_2_prt_2                                        |         2 |        1
+ p3_sales                                                        |         0 |        0
+ p3_sales_1_prt_2                                                |         0 |        0
+ p3_sales_1_prt_2_2_prt_2                                        |         0 |        0
  p3_sales_1_prt_2_2_prt_2_3_prt_other_regions                    |         0 |        1
  p3_sales_1_prt_2_2_prt_2_3_prt_usa                              |         2 |        1
- p3_sales_1_prt_2_2_prt_other_months                             |         0 |        1
+ p3_sales_1_prt_2_2_prt_other_months                             |         0 |        0
  p3_sales_1_prt_2_2_prt_other_months_3_prt_other_regions         |         0 |        1
  p3_sales_1_prt_2_2_prt_other_months_3_prt_usa                   |         0 |        1
- p3_sales_1_prt_outlying_years                                   |         0 |        1
- p3_sales_1_prt_outlying_years_2_prt_2                           |         0 |        1
+ p3_sales_1_prt_outlying_years                                   |         0 |        0
+ p3_sales_1_prt_outlying_years_2_prt_2                           |         0 |        0
  p3_sales_1_prt_outlying_years_2_prt_2_3_prt_other_regions       |         0 |        1
  p3_sales_1_prt_outlying_years_2_prt_2_3_prt_usa                 |         0 |        1
  p3_sales_1_prt_outlying_years_2_prt_other_m_3_prt_other_regions |         0 |        1
- p3_sales_1_prt_outlying_years_2_prt_other_months                |         0 |        1
+ p3_sales_1_prt_outlying_years_2_prt_other_months                |         0 |        0
  p3_sales_1_prt_outlying_years_2_prt_other_months_3_prt_usa      |         0 |        1
 (15 rows)
 
 select * from pg_stats where tablename like 'p3_sales%' order by tablename, attname;
- schemaname |             tablename              | attname | null_frac | avg_width | n_distinct | most_common_vals | most_common_freqs | histogram_bounds | correlation 
-------------+------------------------------------+---------+-----------+-----------+------------+------------------+-------------------+------------------+-------------
- public     | p3_sales                           | day     |         0 |         4 |       -0.5 | {20}             | {1}               |                  |           1
- public     | p3_sales                           | id      |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
- public     | p3_sales                           | month   |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
- public     | p3_sales                           | region  |         0 |         4 |       -0.5 | {usa}            | {1}               |                  |           1
- public     | p3_sales                           | year    |         0 |         4 |       -0.5 | {2002}           | {1}               |                  |           1
- public     | p3_sales_1_prt_2                   | day     |         0 |         4 |       -0.5 | {20}             | {1}               |                  |           1
- public     | p3_sales_1_prt_2                   | id      |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
- public     | p3_sales_1_prt_2                   | month   |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
- public     | p3_sales_1_prt_2                   | region  |         0 |         4 |       -0.5 | {usa}            | {1}               |                  |           1
- public     | p3_sales_1_prt_2                   | year    |         0 |         4 |       -0.5 | {2002}           | {1}               |                  |           1
- public     | p3_sales_1_prt_2_2_prt_2           | day     |         0 |         4 |       -0.5 | {20}             | {1}               |                  |           1
- public     | p3_sales_1_prt_2_2_prt_2           | id      |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
- public     | p3_sales_1_prt_2_2_prt_2           | month   |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
- public     | p3_sales_1_prt_2_2_prt_2           | region  |         0 |         4 |       -0.5 | {usa}            | {1}               |                  |           1
- public     | p3_sales_1_prt_2_2_prt_2           | year    |         0 |         4 |       -0.5 | {2002}           | {1}               |                  |           1
- public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | day     |         0 |         4 |       -0.5 | {20}             | {1}               |                  |           1
- public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | id      |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
- public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | month   |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
- public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | region  |         0 |         4 |       -0.5 | {usa}            | {1}               |                  |           1
- public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | year    |         0 |         4 |       -0.5 | {2002}           | {1}               |                  |           1
+ schemaname |             tablename              | attname | inherited | null_frac | avg_width | n_distinct | most_common_vals | most_common_freqs | histogram_bounds | correlation 
+------------+------------------------------------+---------+-----------+-----------+-----------+------------+------------------+-------------------+------------------+-------------
+ public     | p3_sales                           | day     | t         |         0 |         4 |       -0.5 | {20}             | {1}               |                  |           1
+ public     | p3_sales                           | id      | t         |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
+ public     | p3_sales                           | month   | t         |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
+ public     | p3_sales                           | region  | t         |         0 |         4 |       -0.5 | {usa}            | {1}               |                  |           1
+ public     | p3_sales                           | year    | t         |         0 |         4 |       -0.5 | {2002}           | {1}               |                  |           1
+ public     | p3_sales_1_prt_2                   | day     | t         |         0 |         4 |       -0.5 | {20}             | {1}               |                  |           1
+ public     | p3_sales_1_prt_2                   | id      | t         |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
+ public     | p3_sales_1_prt_2                   | month   | t         |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
+ public     | p3_sales_1_prt_2                   | region  | t         |         0 |         4 |       -0.5 | {usa}            | {1}               |                  |           1
+ public     | p3_sales_1_prt_2                   | year    | t         |         0 |         4 |       -0.5 | {2002}           | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2           | day     | t         |         0 |         4 |       -0.5 | {20}             | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2           | id      | t         |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2           | month   | t         |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2           | region  | t         |         0 |         4 |       -0.5 | {usa}            | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2           | year    | t         |         0 |         4 |       -0.5 | {2002}           | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | day     | f         |         0 |         4 |       -0.5 | {20}             | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | id      | f         |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | month   | f         |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | region  | f         |         0 |         4 |       -0.5 | {usa}            | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | year    | f         |         0 |         4 |       -0.5 | {2002}           | {1}               |                  |           1
 (20 rows)
 
 -- Case 12: Analyzing root table using ROOTPARTITION keyword with GUC optimizer_analyze_root_partition and optimizer_analyze_midlevel_partition set to ON should only update the stats for root partition.
@@ -601,7 +601,7 @@ analyze rootpartition p3_sales;
 select relname, reltuples, relpages from pg_class where relname like 'p3_sales%' order by relname;
                              relname                             | reltuples | relpages 
 -----------------------------------------------------------------+-----------+----------
- p3_sales                                                        |         2 |        1
+ p3_sales                                                        |         0 |        0
  p3_sales_1_prt_2                                                |         0 |        0
  p3_sales_1_prt_2_2_prt_2                                        |         0 |        0
  p3_sales_1_prt_2_2_prt_2_3_prt_other_regions                    |         0 |        0
@@ -619,13 +619,13 @@ select relname, reltuples, relpages from pg_class where relname like 'p3_sales%'
 (15 rows)
 
 select * from pg_stats where tablename like 'p3_sales%' order by tablename, attname;
- schemaname | tablename | attname | null_frac | avg_width | n_distinct | most_common_vals | most_common_freqs | histogram_bounds | correlation 
-------------+-----------+---------+-----------+-----------+------------+------------------+-------------------+------------------+-------------
- public     | p3_sales  | day     |         0 |         4 |       -0.5 | {20}             | {1}               |                  |           1
- public     | p3_sales  | id      |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
- public     | p3_sales  | month   |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
- public     | p3_sales  | region  |         0 |         4 |       -0.5 | {usa}            | {1}               |                  |           1
- public     | p3_sales  | year    |         0 |         4 |       -0.5 | {2002}           | {1}               |                  |           1
+ schemaname | tablename | attname | inherited | null_frac | avg_width | n_distinct | most_common_vals | most_common_freqs | histogram_bounds | correlation 
+------------+-----------+---------+-----------+-----------+-----------+------------+------------------+-------------------+------------------+-------------
+ public     | p3_sales  | day     | t         |         0 |         4 |       -0.5 | {20}             | {1}               |                  |           1
+ public     | p3_sales  | id      | t         |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
+ public     | p3_sales  | month   | t         |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
+ public     | p3_sales  | region  | t         |         0 |         4 |       -0.5 | {usa}            | {1}               |                  |           1
+ public     | p3_sales  | year    | t         |         0 |         4 |       -0.5 | {2002}           | {1}               |                  |           1
 (5 rows)
 
 -- Case 13: Analyzing root table using ROOTPARTITION keyword with GUC optimizer_analyze_root_partition and optimizer_analyze_midlevel_partition set to OFF should update the stats for root partition only.
@@ -652,7 +652,7 @@ analyze rootpartition p3_sales;
 select relname, reltuples, relpages from pg_class where relname like 'p3_sales%' order by relname;
                              relname                             | reltuples | relpages 
 -----------------------------------------------------------------+-----------+----------
- p3_sales                                                        |         2 |        1
+ p3_sales                                                        |         0 |        0
  p3_sales_1_prt_2                                                |         0 |        0
  p3_sales_1_prt_2_2_prt_2                                        |         0 |        0
  p3_sales_1_prt_2_2_prt_2_3_prt_other_regions                    |         0 |        0
@@ -670,13 +670,13 @@ select relname, reltuples, relpages from pg_class where relname like 'p3_sales%'
 (15 rows)
 
 select * from pg_stats where tablename like 'p3_sales%' order by tablename, attname;
- schemaname | tablename | attname | null_frac | avg_width | n_distinct | most_common_vals | most_common_freqs | histogram_bounds | correlation 
-------------+-----------+---------+-----------+-----------+------------+------------------+-------------------+------------------+-------------
- public     | p3_sales  | day     |         0 |         4 |       -0.5 | {20}             | {1}               |                  |           1
- public     | p3_sales  | id      |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
- public     | p3_sales  | month   |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
- public     | p3_sales  | region  |         0 |         4 |       -0.5 | {usa}            | {1}               |                  |           1
- public     | p3_sales  | year    |         0 |         4 |       -0.5 | {2002}           | {1}               |                  |           1
+ schemaname | tablename | attname | inherited | null_frac | avg_width | n_distinct | most_common_vals | most_common_freqs | histogram_bounds | correlation 
+------------+-----------+---------+-----------+-----------+-----------+------------+------------------+-------------------+------------------+-------------
+ public     | p3_sales  | day     | t         |         0 |         4 |       -0.5 | {20}             | {1}               |                  |           1
+ public     | p3_sales  | id      | t         |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
+ public     | p3_sales  | month   | t         |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
+ public     | p3_sales  | region  | t         |         0 |         4 |       -0.5 | {usa}            | {1}               |                  |           1
+ public     | p3_sales  | year    | t         |         0 |         4 |       -0.5 | {2002}           | {1}               |                  |           1
 (5 rows)
 
 -- Case 14: Analyzing root table with GUC optimizer_analyze_root_partition set to OFF and optimizer_analyze_midlevel_partition set to On should update the stats for midlevel and leaf partition only.
@@ -703,41 +703,41 @@ analyze p3_sales;
 select relname, reltuples, relpages from pg_class where relname like 'p3_sales%' order by relname;
                              relname                             | reltuples | relpages 
 -----------------------------------------------------------------+-----------+----------
- p3_sales                                                        |         0 |        1
- p3_sales_1_prt_2                                                |         2 |        1
- p3_sales_1_prt_2_2_prt_2                                        |         2 |        1
+ p3_sales                                                        |         0 |        0
+ p3_sales_1_prt_2                                                |         0 |        0
+ p3_sales_1_prt_2_2_prt_2                                        |         0 |        0
  p3_sales_1_prt_2_2_prt_2_3_prt_other_regions                    |         0 |        1
  p3_sales_1_prt_2_2_prt_2_3_prt_usa                              |         2 |        1
- p3_sales_1_prt_2_2_prt_other_months                             |         0 |        1
+ p3_sales_1_prt_2_2_prt_other_months                             |         0 |        0
  p3_sales_1_prt_2_2_prt_other_months_3_prt_other_regions         |         0 |        1
  p3_sales_1_prt_2_2_prt_other_months_3_prt_usa                   |         0 |        1
- p3_sales_1_prt_outlying_years                                   |         0 |        1
- p3_sales_1_prt_outlying_years_2_prt_2                           |         0 |        1
+ p3_sales_1_prt_outlying_years                                   |         0 |        0
+ p3_sales_1_prt_outlying_years_2_prt_2                           |         0 |        0
  p3_sales_1_prt_outlying_years_2_prt_2_3_prt_other_regions       |         0 |        1
  p3_sales_1_prt_outlying_years_2_prt_2_3_prt_usa                 |         0 |        1
  p3_sales_1_prt_outlying_years_2_prt_other_m_3_prt_other_regions |         0 |        1
- p3_sales_1_prt_outlying_years_2_prt_other_months                |         0 |        1
+ p3_sales_1_prt_outlying_years_2_prt_other_months                |         0 |        0
  p3_sales_1_prt_outlying_years_2_prt_other_months_3_prt_usa      |         0 |        1
 (15 rows)
 
 select * from pg_stats where tablename like 'p3_sales%' order by tablename, attname;
- schemaname |             tablename              | attname | null_frac | avg_width | n_distinct | most_common_vals | most_common_freqs | histogram_bounds | correlation 
-------------+------------------------------------+---------+-----------+-----------+------------+------------------+-------------------+------------------+-------------
- public     | p3_sales_1_prt_2                   | day     |         0 |         4 |       -0.5 | {20}             | {1}               |                  |           1
- public     | p3_sales_1_prt_2                   | id      |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
- public     | p3_sales_1_prt_2                   | month   |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
- public     | p3_sales_1_prt_2                   | region  |         0 |         4 |       -0.5 | {usa}            | {1}               |                  |           1
- public     | p3_sales_1_prt_2                   | year    |         0 |         4 |       -0.5 | {2002}           | {1}               |                  |           1
- public     | p3_sales_1_prt_2_2_prt_2           | day     |         0 |         4 |       -0.5 | {20}             | {1}               |                  |           1
- public     | p3_sales_1_prt_2_2_prt_2           | id      |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
- public     | p3_sales_1_prt_2_2_prt_2           | month   |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
- public     | p3_sales_1_prt_2_2_prt_2           | region  |         0 |         4 |       -0.5 | {usa}            | {1}               |                  |           1
- public     | p3_sales_1_prt_2_2_prt_2           | year    |         0 |         4 |       -0.5 | {2002}           | {1}               |                  |           1
- public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | day     |         0 |         4 |       -0.5 | {20}             | {1}               |                  |           1
- public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | id      |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
- public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | month   |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
- public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | region  |         0 |         4 |       -0.5 | {usa}            | {1}               |                  |           1
- public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | year    |         0 |         4 |       -0.5 | {2002}           | {1}               |                  |           1
+ schemaname |             tablename              | attname | inherited | null_frac | avg_width | n_distinct | most_common_vals | most_common_freqs | histogram_bounds | correlation 
+------------+------------------------------------+---------+-----------+-----------+-----------+------------+------------------+-------------------+------------------+-------------
+ public     | p3_sales_1_prt_2                   | day     | t         |         0 |         4 |       -0.5 | {20}             | {1}               |                  |           1
+ public     | p3_sales_1_prt_2                   | id      | t         |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
+ public     | p3_sales_1_prt_2                   | month   | t         |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
+ public     | p3_sales_1_prt_2                   | region  | t         |         0 |         4 |       -0.5 | {usa}            | {1}               |                  |           1
+ public     | p3_sales_1_prt_2                   | year    | t         |         0 |         4 |       -0.5 | {2002}           | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2           | day     | t         |         0 |         4 |       -0.5 | {20}             | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2           | id      | t         |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2           | month   | t         |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2           | region  | t         |         0 |         4 |       -0.5 | {usa}            | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2           | year    | t         |         0 |         4 |       -0.5 | {2002}           | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | day     | f         |         0 |         4 |       -0.5 | {20}             | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | id      | f         |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | month   | f         |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | region  | f         |         0 |         4 |       -0.5 | {usa}            | {1}               |                  |           1
+ public     | p3_sales_1_prt_2_2_prt_2_3_prt_usa | year    | f         |         0 |         4 |       -0.5 | {2002}           | {1}               |                  |           1
 (15 rows)
 
 -- Case 15: Analyzing root table using ROOTPARTITION keyword with GUC optimizer_analyze_root_partition set to OFF and optimizer_analyze_midlevel_partition set to ON should only update the stats for root only.
@@ -764,7 +764,7 @@ analyze rootpartition p3_sales;
 select relname, reltuples, relpages from pg_class where relname like 'p3_sales%' order by relname;
                              relname                             | reltuples | relpages 
 -----------------------------------------------------------------+-----------+----------
- p3_sales                                                        |         2 |        1
+ p3_sales                                                        |         0 |        0
  p3_sales_1_prt_2                                                |         0 |        0
  p3_sales_1_prt_2_2_prt_2                                        |         0 |        0
  p3_sales_1_prt_2_2_prt_2_3_prt_other_regions                    |         0 |        0
@@ -782,13 +782,13 @@ select relname, reltuples, relpages from pg_class where relname like 'p3_sales%'
 (15 rows)
 
 select * from pg_stats where tablename like 'p3_sales%' order by tablename, attname;
- schemaname | tablename | attname | null_frac | avg_width | n_distinct | most_common_vals | most_common_freqs | histogram_bounds | correlation 
-------------+-----------+---------+-----------+-----------+------------+------------------+-------------------+------------------+-------------
- public     | p3_sales  | day     |         0 |         4 |       -0.5 | {20}             | {1}               |                  |           1
- public     | p3_sales  | id      |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
- public     | p3_sales  | month   |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
- public     | p3_sales  | region  |         0 |         4 |       -0.5 | {usa}            | {1}               |                  |           1
- public     | p3_sales  | year    |         0 |         4 |       -0.5 | {2002}           | {1}               |                  |           1
+ schemaname | tablename | attname | inherited | null_frac | avg_width | n_distinct | most_common_vals | most_common_freqs | histogram_bounds | correlation 
+------------+-----------+---------+-----------+-----------+-----------+------------+------------------+-------------------+------------------+-------------
+ public     | p3_sales  | day     | t         |         0 |         4 |       -0.5 | {20}             | {1}               |                  |           1
+ public     | p3_sales  | id      | t         |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
+ public     | p3_sales  | month   | t         |         0 |         4 |       -0.5 | {1}              | {1}               |                  |           1
+ public     | p3_sales  | region  | t         |         0 |         4 |       -0.5 | {usa}            | {1}               |                  |           1
+ public     | p3_sales  | year    | t         |         0 |         4 |       -0.5 | {2002}           | {1}               |                  |           1
 (5 rows)
 
 -- start_ignore
@@ -820,9 +820,9 @@ SELECT schemaname, tablename, attname, null_frac, avg_width, n_distinct, most_co
 (4 rows)
 
 SELECT schemaname, tablename, attname, null_frac, avg_width, n_distinct, most_common_vals, most_common_freqs, histogram_bounds FROM pg_stats WHERE tablename='expression_idx_foo_stats' ORDER BY attname;
- schemaname |        tablename         |     attname     | null_frac | avg_width | n_distinct | most_common_vals | most_common_freqs | histogram_bounds 
-------------+--------------------------+-----------------+-----------+-----------+------------+------------------+-------------------+------------------
- public     | expression_idx_foo_stats | pg_expression_1 |       0.5 |         7 |      -0.25 | {AAA}            | {0.5}             | 
+ schemaname |        tablename         | attname | null_frac | avg_width | n_distinct | most_common_vals | most_common_freqs | histogram_bounds 
+------------+--------------------------+---------+-----------+-----------+------------+------------------+-------------------+------------------
+ public     | expression_idx_foo_stats | upper   |       0.5 |         7 |      -0.25 | {AAA}            | {0.5}             | 
 (1 row)
 
 DROP TABLE IF EXISTS foo_stats;


### PR DESCRIPTION
Column stainherit has been added in pg_statistic in upstream.

* Skip normal non-recursive ANALYZE for partitioned tables,
  which don't contain any rows.

* Fix the expected results in analyze.out