### PR TITLE
Ensure that shared buffers are used for temp tables in Greenplum 

### DIFF
--- a/src/backend/access/heap/heapam.c
+++ b/src/backend/access/heap/heapam.c
@@ -912,9 +912,12 @@ relation_open(Oid relationId, LOCKMODE lockmode)
 				 errdetail("This can be validly caused by a concurrent delete operation on this object.")));
 	}
 
+	/* Disabled in GPDB as per comment in PrepareTransaction(). */
+#if 0
 	/* Make note that we've accessed a temporary relation */
 	if (RelationUsesLocalBuffers(r))
 		MyXactAccessedTempRel = true;
+#endif
 
 	pgstat_initstats(r);
 
@@ -978,9 +981,12 @@ try_relation_open(Oid relationId, LOCKMODE lockmode, bool noWait)
 				 errdetail("This can be validly caused by a concurrent delete operation on this object.")));
 	}
 
+	/* Disabled in GPDB as per comment in PrepareTransaction(). */
+#if 0
 	/* Make note that we've accessed a temporary relation */
 	if (RelationUsesLocalBuffers(r))
 		MyXactAccessedTempRel = true;
+#endif
 
 	pgstat_initstats(r);
 

--- a/src/backend/access/nbtree/nbtsort.c
+++ b/src/backend/access/nbtree/nbtsort.c
@@ -287,8 +287,6 @@ _bt_blwritepage(BTWriteState *wstate, Page page, BlockNumber blkno)
 		if (!wstate->btws_zeropage)
 			wstate->btws_zeropage = (Page) palloc0(BLCKSZ);
 
-		// UNDONE: Unfortunately, I think we write temp relations to the mirror...
-
 		/* don't set checksum for all-zero page */
 		smgrextend(wstate->index->rd_smgr, MAIN_FORKNUM,
 				   wstate->btws_pages_written++,
@@ -296,8 +294,6 @@ _bt_blwritepage(BTWriteState *wstate, Page page, BlockNumber blkno)
 				   true);
 	}
 
-
-	// UNDONE: Unfortunately, I think we write temp relations to the mirror...
 	PageSetChecksumInplace(page, blkno);
 
 	/*

--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -98,7 +98,9 @@ int			CommitSiblings = 5; /* # concurrent xacts needed to sleep */
  *
  * Not used in GPDB, see comments in PrepareTransaction()
  */
+#if 0
 bool		MyXactAccessedTempRel = false;
+#endif
 
 int32 gp_subtrans_warn_limit = 16777216; /* 16 million */
 
@@ -2164,7 +2166,10 @@ StartTransaction(void)
 	XactDeferrable = DefaultXactDeferrable;
 	XactIsoLevel = DefaultXactIsoLevel;
 	forceSyncCommit = false;
+	/* Disabled in GPDB as per comment in PrepareTransaction(). */
+#if 0
 	MyXactAccessedTempRel = false;
+#endif
 	seqXlogWrite = false;
 
 	/* set read only by fts, if any fts action is read only */

--- a/src/backend/storage/buffer/bufmgr.c
+++ b/src/backend/storage/buffer/bufmgr.c
@@ -1285,7 +1285,7 @@ BufferSync(int flags)
 	 * buffers.  But at shutdown time, we write all dirty buffers.
 	 */
 	if (!(flags & CHECKPOINT_IS_SHUTDOWN))
-		flags |= BM_PERMANENT;
+		mask |= BM_PERMANENT;
 
 	/*
 	 * Loop over all buffers, and mark the ones that need to be written with

--- a/src/backend/storage/buffer/localbuf.c
+++ b/src/backend/storage/buffer/localbuf.c
@@ -110,6 +110,13 @@ LocalBufferAlloc(SMgrRelation smgr, ForkNumber forkNum, BlockNumber blockNum,
 	int			trycounter;
 	bool		found;
 
+	/*
+	 * Local buffers are used for temp tables in PostgreSQL.  As temp tables
+	 * use shared buffers in Greenplum, we shouldn't be useing local buffers
+	 * for anything.
+	 */
+	Assert(false);
+
 	INIT_BUFFERTAG(newTag, smgr->smgr_rnode.node, forkNum, blockNum);
 
 	/* Initialize local buffers if first request in this session */
@@ -301,6 +308,12 @@ DropRelFileNodeLocalBuffers(RelFileNode rnode, ForkNumber forkNum,
 {
 	int			i;
 
+	/*
+	 * Local buffers are used for temp tables in PostgreSQL.  As temp tables
+	 * use shared buffers in Greenplum, we shouldn't be useing local buffers
+	 * for anything.
+	 */
+	Assert(false);
 	for (i = 0; i < NLocBuffer; i++)
 	{
 		BufferDesc *bufHdr = &LocalBufferDescriptors[i];

--- a/src/include/access/xact.h
+++ b/src/include/access/xact.h
@@ -66,8 +66,11 @@ typedef enum
 /* Synchronous commit level */
 extern int	synchronous_commit;
 
+/* Disabled in GPDB as per comment in PrepareTransaction(). */
+#if 0
 /* Kluge for 2PC support */
 extern bool MyXactAccessedTempRel;
+#endif
 
 /*
  *	start- and end-of-transaction callbacks for dynamically loaded modules

--- a/src/include/storage/buf_internals.h
+++ b/src/include/storage/buf_internals.h
@@ -37,8 +37,9 @@
 #define BM_JUST_DIRTIED			(1 << 5)		/* dirtied since write started */
 #define BM_PIN_COUNT_WAITER		(1 << 6)		/* have waiter for sole pin */
 #define BM_CHECKPOINT_NEEDED	(1 << 7)		/* must write for checkpoint */
-#define BM_PERMANENT			(1 << 8)		/* permanent relation (not
-												 * unlogged) */
+#define BM_PERMANENT			(1 << 8)		/* permanent relation (neither
+												 * unlogged or temporary) */
+#define BM_TEMP					(1 << 9)		/* temporary relation */
 
 typedef bits16 BufFlags;
 

--- a/src/include/utils/rel.h
+++ b/src/include/utils/rel.h
@@ -28,8 +28,6 @@
 #include "storage/relfilenode.h"
 #include "utils/relcache.h"
 
-#include "cdb/cdbvars.h"
-
 
 /*
  * LockRelId and LockInfo really belong to lmgr.h, but it's more convenient
@@ -466,20 +464,11 @@ typedef struct StdRdOptions
  * RelationUsesLocalBuffers
  *		True if relation's pages are stored in local buffers.
  *
- * GPDB: On QEs, temp relations must use shared buffer cache so data
- * will be visible to all segmates.  On QD, sequence objects must
- * use shared buffer cache so data will be visible to sequence server.
+ * In GPDB, we do not use local buffers for temp tables because segmates need
+ * to share temp table contents.  Currently, there is no other reason to use
+ * local buffers.
  */
-static inline bool
-RelationUsesLocalBuffers(Relation relation)
-{
-	if (relation->rd_rel->relpersistence == RELPERSISTENCE_TEMP &&
-		relation->rd_rel->relkind != RELKIND_SEQUENCE &&
-		Gp_role != GP_ROLE_EXECUTE)
-		return true;
-	else
-		return false;
-}
+#define RelationUsesLocalBuffers(relation) false
 
 /*
  * RelationUsesTempNamespace


### PR DESCRIPTION
I've tried to minimize code changes by using a new bit from BufFlags to identify buffers belonging to temp tables in shared buffer cache.  Not sure if this is the right way to go forward, please take a look.