### PR TITLE
Use correct row number when calculating join costs.

### DIFF
--- a/src/backend/cdb/cdbpath.c
+++ b/src/backend/cdb/cdbpath.c
@@ -276,6 +276,7 @@ cdbpath_create_motion_path(PlannerInfo *root,
 	pathnode->path.pathtype = T_Motion;
 	pathnode->path.parent = subpath->parent;
 	pathnode->path.locus = locus;
+	pathnode->path.rows = subpath->parent->rows;
 	pathnode->path.pathkeys = pathkeys;
 	pathnode->subpath = subpath;
 

--- a/src/backend/optimizer/path/costsize.c
+++ b/src/backend/optimizer/path/costsize.c
@@ -96,13 +96,6 @@
 
 #define LOG2(x)  (log(x) / 0.693147180559945)
 
-/*
- * Some Paths return less than the nominal number of rows of their parent
- * relations; join nodes need to do this to get the correct input count:
- */
-#define PATH_ROWS(root, path) (cdbpath_rows((root), (path)))
-
-
 double		seq_page_cost = DEFAULT_SEQ_PAGE_COST;
 double		random_page_cost = DEFAULT_RANDOM_PAGE_COST;
 double		cpu_tuple_cost = DEFAULT_CPU_TUPLE_COST;
@@ -2002,7 +1995,7 @@ initial_cost_nestloop(PlannerInfo *root, JoinCostWorkspace *workspace,
 {
 	Cost		startup_cost = 0;
 	Cost		run_cost = 0;
-	double		outer_path_rows = outer_path->rows;
+	double		outer_path_rows = cdbpath_rows(root, outer_path);
 	Cost		inner_rescan_start_cost;
 	Cost		inner_rescan_total_cost;
 	Cost		inner_run_cost;
@@ -2105,8 +2098,8 @@ final_cost_nestloop(PlannerInfo *root, NestPath *path,
 {
 	Path	   *outer_path = path->outerjoinpath;
 	Path	   *inner_path = path->innerjoinpath;
-	double		outer_path_rows = outer_path->rows;
-	double		inner_path_rows = inner_path->rows;
+	double		outer_path_rows = cdbpath_rows(root, outer_path);
+	double		inner_path_rows = cdbpath_rows(root, inner_path);
 	Cost		startup_cost = workspace->startup_cost;
 	Cost		run_cost = workspace->run_cost;
 	Cost		inner_rescan_run_cost = workspace->inner_rescan_run_cost;
@@ -2226,8 +2219,8 @@ initial_cost_mergejoin(PlannerInfo *root, JoinCostWorkspace *workspace,
 {
 	Cost		startup_cost = 0;
 	Cost		run_cost = 0;
-	double		outer_path_rows = outer_path->rows;
-	double		inner_path_rows = inner_path->rows;
+	double		outer_path_rows = cdbpath_rows(root, outer_path);
+	double		inner_path_rows = cdbpath_rows(root, inner_path);
 	Cost		inner_run_cost;
 	double		outer_rows,
 				inner_rows,
@@ -2451,7 +2444,7 @@ final_cost_mergejoin(PlannerInfo *root, MergePath *path,
 {
 	Path	   *outer_path = path->jpath.outerjoinpath;
 	Path	   *inner_path = path->jpath.innerjoinpath;
-	double		inner_path_rows = inner_path->rows;
+	double		inner_path_rows = cdbpath_rows(root, inner_path);
 	List	   *mergeclauses = path->path_mergeclauses;
 	List	   *innersortkeys = path->innersortkeys;
 	Cost		startup_cost = workspace->startup_cost;
@@ -2741,8 +2734,8 @@ initial_cost_hashjoin(PlannerInfo *root, JoinCostWorkspace *workspace,
 {
 	Cost		startup_cost = 0;
 	Cost		run_cost = 0;
-	double		outer_path_rows = outer_path->rows;
-	double		inner_path_rows = inner_path->rows;
+	double		outer_path_rows = cdbpath_rows(root, outer_path);
+	double		inner_path_rows = cdbpath_rows(root, inner_path);
 	int			num_hashclauses = list_length(hashclauses);
 	int			numbuckets;
 	int			numbatches;
@@ -2825,8 +2818,8 @@ final_cost_hashjoin(PlannerInfo *root, HashPath *path,
 {
 	Path	   *outer_path = path->jpath.outerjoinpath;
 	Path	   *inner_path = path->jpath.innerjoinpath;
-	double		outer_path_rows = outer_path->rows;
-	double		inner_path_rows = inner_path->rows;
+	double		outer_path_rows = cdbpath_rows(root, outer_path);
+	double		inner_path_rows = cdbpath_rows(root, inner_path);
 	List	   *hashclauses = path->path_hashclauses;
 	Cost		startup_cost = workspace->startup_cost;
 	Cost		run_cost = workspace->run_cost;

--- a/src/backend/optimizer/util/pathnode.c
+++ b/src/backend/optimizer/util/pathnode.c
@@ -2326,6 +2326,7 @@ create_unique_rowid_path(PlannerInfo *root,
         motionpath.path.type = T_CdbMotionPath;
         motionpath.path.parent = subpath->parent;
         motionpath.path.locus = pathnode->path.locus;
+        motionpath.path.rows = subpath->parent->rows;
         motionpath.subpath = subpath;
         cdbpath_cost_motion(root, &motionpath);
 

--- a/src/backend/optimizer/util/relnode.c
+++ b/src/backend/optimizer/util/relnode.c
@@ -31,6 +31,7 @@
 #include "utils/hsearch.h"
 #include "utils/lsyscache.h"
 
+#include "cdb/cdbpath.h"
 
 typedef struct JoinHashEntry
 {
@@ -1126,8 +1127,8 @@ get_joinrel_parampathinfo(PlannerInfo *root, RelOptInfo *joinrel,
 
 	/* Estimate the number of rows returned by the parameterized join */
 	rows = get_parameterized_joinrel_size(root, joinrel,
-										  outer_path->rows,
-										  inner_path->rows,
+										  cdbpath_rows(root, outer_path),
+										  cdbpath_rows(root, inner_path),
 										  sjinfo,
 										  *restrict_clauses);
 

--- a/src/include/cdb/cdbpath.h
+++ b/src/include/cdb/cdbpath.h
@@ -52,21 +52,14 @@ cdbpath_contains_wts(Path *path);
 static inline double
 cdbpath_rows(PlannerInfo *root, Path *path)
 {
-    Path  *p;
-
-	p = (IsA(path, CdbMotionPath))  ? ((CdbMotionPath *)path)->subpath
-		: path;
-
-	if (IsA(p, BitmapHeapPath) ||
-			IsA(p, BitmapAppendOnlyPath) ||
-			IsA(p, IndexPath) ||
-			IsA(p, UniquePath))
-		return p->rows;
-
+	/* GPDB_92_MERGE_FIXME: Maybe we should think about removing this function.
+	 * That will eliminate merge risk since pg upstream (since 9.2) uses
+	 * path->rows directly.
+	 */
 	if (CdbPathLocus_IsReplicated(path->locus))
-		return  (path->parent->rows * root->config->cdbpath_segments);
-
-	return  path->parent->rows;
+		return path->rows * root->config->cdbpath_segments;
+	else
+		return path->rows;
 }                               /* cdbpath_rows */
 
 #endif   /* CDBPATH_H */


### PR DESCRIPTION
Below is relevant upstream patch. 

commit e2fa76d80ba571d4de8992de6386536867250474
Author: Tom Lane <tgl@sss.pgh.pa.us>
Date:   Fri Jan 27 19:26:38 2012 -0500

    Use parameterized paths to generate inner indexscans more flexibly.

    This patch fixes the planner so that it can generate nestloop-with-
    inner-indexscan plans even with one or more levels of joining between
    the indexscan and the nestloop join that is supplying the parameter.
    The executor was fixed to handle such cases some time ago, but the
    planner was not ready.  This should improve our plans in many situations
    where join ordering restrictions formerly forced complete table scans.

    There is probably a fair amount of tuning work yet to be done, because
    of various heuristics that have been added to limit the number of
    parameterized paths considered.  However, we are not going to find out
    what needs to be adjusted until the code gets some real-world use, so
    it's time to get it in there where it can be tested easily.

    Note API change for index AM amcostestimate functions.  I'm not aware of
    any non-core index AMs, but if there are any, they will need minor
    adjustments.
