### PR TITLE
Fix drop inherit table failure

### DIFF
--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -875,16 +875,13 @@ standard_ProcessUtility(Node *parsetree,
 		case T_DropStmt:
 			{
 				DropStmt   *stmt = (DropStmt *) parsetree;
-				ListCell   *arg;
-				List	   *objects;
-				bool		if_exists;
+				DropStmt   *copyStmt;
 
-				if_exists = stmt->missing_ok;
 				/* stmt->objects could be modified (e.g.
 				 * CREATE TABLE test_exists(a int, b int);
 				 * DROP TRIGGER IF EXISTS test_trigger_exists ON test_exists;)
 				 * so copy for later use. */
-				objects = copyObject(stmt->objects);
+				copyStmt = copyObject(stmt);
 
 				switch (stmt->removeType)
 				{
@@ -911,28 +908,13 @@ standard_ProcessUtility(Node *parsetree,
 				}
 
 				/* we modify the object in the loop below, so make a copy */
-				stmt = copyObject(stmt);
-
-				foreach(arg, objects)
-				{
-					List	   *names = (List *) lfirst(arg);
-
-					stmt->objects = NIL;
-					stmt->objects = lappend(stmt->objects, list_copy(names));
-					stmt->missing_ok = if_exists;
-
-					/*
-					 * If we are the QD, dispatch this DROP command to all the
-					 * QEs
-					 */
-					if (Gp_role == GP_ROLE_DISPATCH)
-						CdbDispatchUtilityStatement((Node *) stmt,
-													DF_CANCEL_ON_ERROR|
-													DF_WITH_SNAPSHOT|
-													DF_NEED_TWO_PHASE,
-													NIL,
-													NULL);
-				}
+				if (Gp_role == GP_ROLE_DISPATCH)
+					CdbDispatchUtilityStatement((Node *) copyStmt,
+												DF_CANCEL_ON_ERROR|
+												DF_WITH_SNAPSHOT|
+												DF_NEED_TWO_PHASE,
+												NIL,
+												NULL);
 			}
 			break;
 

--- a/src/test/regress/expected/inherit.out
+++ b/src/test/regress/expected/inherit.out
@@ -541,12 +541,8 @@ SELECT relname, d.* FROM ONLY d, pg_class where d.tableoid = pg_class.oid;
 CREATE TEMP TABLE z (b TEXT, PRIMARY KEY(aa, b)) inherits (a);
 NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit index "z_pkey" for table "z"
 INSERT INTO z VALUES (NULL, 'text'); -- should fail
-<<<<<<< HEAD
-ERROR:  null value in column "dummy" violates not-null constraint
-=======
-ERROR:  null value in column "aa" violates not-null constraint
-DETAIL:  Failing row contains (null, text).
->>>>>>> 80edfd76591fdb9beec061de3c05ef4e9d96ce56
+ERROR:  null value in column "dummy" violates not-null constraint  (seg1 172.17.0.2:25433 pid=366731)
+DETAIL:  Failing row contains (null, text, null).
 -- Check UPDATE with inherited target and an inherited source table
 create temp table foo(f1 int, f2 int);
 create temp table foo2(f3 int) inherits (foo);
@@ -565,20 +561,18 @@ insert into bar2 values(2,2,2);
 insert into bar2 values(3,3,3);
 insert into bar2 values(4,4,4);
 update bar set f2 = f2 + 100 where f1 in (select f1 from foo);
- ERROR:  Cannot parallelize that UPDATE yet
- DETAIL:  Result depends on values of CTID system column.  Support for CTID system column may change in the future.
 SELECT relname, bar.* FROM bar, pg_class where bar.tableoid = pg_class.oid
 order by 1,2;
  relname | f1 | f2  
----------+----+----
- bar     |  1 | 1
- bar     |  2 | 2
- bar     |  3 | 3
- bar     |  4 | 4
- bar2    |  1 | 1
- bar2    |  2 | 2
- bar2    |  3 | 3
- bar2    |  4 | 4
+---------+----+-----
+ bar     |  1 | 101
+ bar     |  2 | 102
+ bar     |  3 | 103
+ bar     |  4 |   4
+ bar2    |  1 | 101
+ bar2    |  2 | 102
+ bar2    |  3 | 103
+ bar2    |  4 |   4
 (8 rows)
 
 /* Test multiple inheritance of column defaults */
@@ -596,98 +590,13 @@ CREATE TABLE otherchild (tomorrow date default now())
 NOTICE:  merging multiple inherited definitions of column "tomorrow"
 NOTICE:  merging column "tomorrow" with inherited definition
 DROP TABLE firstparent, secondparent, jointchild, thirdparent, otherchild;
-<<<<<<< HEAD
-/* Test inheritance of structure (LIKE) */
-CREATE TABLE inhx (xx text DEFAULT 'text');
-/*
- * Test double inheritance
- *
- * Ensure that defaults are NOT included unless
- * INCLUDING DEFAULTS is specified
- */
-CREATE TABLE inhe (ee text, LIKE inhx) inherits (b);
-INSERT INTO inhe VALUES ('ee-col1', 'ee-col2', DEFAULT, 'ee-col4');
-ERROR:  invalid input syntax for integer: "ee-col1"
-SELECT * FROM inhe; /* Columns aa, bb, xx value NULL, ee */
- dummy | aa | bb | ee | xx 
--------+----+----+----+----
-(0 rows)
-
-SELECT * FROM inhx; /* Empty set since LIKE inherits structure only */
- xx 
-----
-(0 rows)
-
-SELECT * FROM b; /* Has ee entry */
- dummy | aa | bb 
--------+----+----
-(0 rows)
-
-SELECT * FROM a; /* Has ee entry */
- dummy | aa 
--------+----
-(0 rows)
-
-CREATE TABLE inhf (LIKE inhx, LIKE inhx); /* Throw error */
-ERROR:  column "xx" specified more than once
-CREATE TABLE inhf (LIKE inhx INCLUDING DEFAULTS INCLUDING CONSTRAINTS);
-INSERT INTO inhf DEFAULT VALUES;
-SELECT * FROM inhf; /* Single entry with value 'text' */
-  xx  
-------
- text
-(1 row)
-
-ALTER TABLE inhx add constraint foo CHECK (xx = 'text');
-ALTER TABLE inhx ADD PRIMARY KEY (xx);
-NOTICE:  ALTER TABLE / ADD PRIMARY KEY will create implicit index "inhx_pkey" for table "inhx"
-CREATE TABLE inhg (LIKE inhx); /* Doesn't copy constraint */
-INSERT INTO inhg VALUES ('foo');
-DROP TABLE inhg;
-CREATE TABLE inhg (x text, LIKE inhx INCLUDING CONSTRAINTS, y text); /* Copies constraints */
-INSERT INTO inhg VALUES ('x', 'text', 'y'); /* Succeeds */
-INSERT INTO inhg VALUES ('x', 'text', 'y'); /* Succeeds -- Unique constraints not copied */
-INSERT INTO inhg VALUES ('x', 'foo',  'y');  /* fails due to constraint */
-ERROR:  new row for relation "inhg" violates check constraint "foo"
-SELECT * FROM inhg; /* Two records with three columns in order x=x, xx=text, y=y */
- x |  xx  | y 
----+------+---
- x | text | y
- x | text | y
-(2 rows)
-
-DROP TABLE inhg;
-CREATE TABLE inhg (x text, LIKE inhx INCLUDING INDEXES, y text); /* copies indexes */
-NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit index "inhg_pkey" for table "inhg"
-INSERT INTO inhg VALUES (5, 10);
-INSERT INTO inhg VALUES (20, 10); -- should fail
-ERROR:  duplicate key value violates unique constraint "inhg_pkey"
-DETAIL:  Key (xx)=(10) already exists.
-DROP TABLE inhg;
-/* Multiple primary keys creation should fail */
-CREATE TABLE inhg (x text, LIKE inhx INCLUDING INDEXES, PRIMARY KEY(x)); /* fails */
-ERROR:  multiple primary keys for table "inhg" are not allowed
-CREATE TABLE inhz (xx text DEFAULT 'text', yy int UNIQUE);
-NOTICE:  CREATE TABLE / UNIQUE will create implicit index "inhz_yy_key" for table "inhz"
-CREATE UNIQUE INDEX inhz_xx_idx on inhz (xx) WHERE xx <> 'test';
-/* Ok to create multiple unique indexes */
-CREATE TABLE inhg (x text UNIQUE, LIKE inhz INCLUDING INDEXES);
-NOTICE:  CREATE TABLE / UNIQUE will create implicit index "inhg_x_key" for table "inhg"
-NOTICE:  CREATE TABLE / UNIQUE will create implicit index "inhg_yy_key" for table "inhg"
-INSERT INTO inhg (xx, yy, x) VALUES ('test', 5, 10);
-INSERT INTO inhg (xx, yy, x) VALUES ('test', 10, 15);
-INSERT INTO inhg (xx, yy, x) VALUES ('foo', 10, 15); -- should fail
-ERROR:  duplicate key value violates unique constraint "inhg_x_key"
-DETAIL:  Key (x)=(15) already exists.
-DROP TABLE inhg;
-DROP TABLE inhz;
-=======
->>>>>>> 80edfd76591fdb9beec061de3c05ef4e9d96ce56
 -- Test changing the type of inherited columns
 insert into d values('test','one','two','three');
 ERROR:  invalid input syntax for integer: "test"
+LINE 1: insert into d values('test','one','two','three');
+                             ^
 alter table a alter column aa type integer using bit_length(aa);
-select * from d ORDER BY 1,2,3;
+select * from d;
  dummy | aa | bb | cc | dd 
 -------+----+----+----+----
 (0 rows)
@@ -715,6 +624,7 @@ Check constraints:
     "p1chk" CHECK NO INHERIT (ff1 > 0)
     "p2chk" CHECK (ff1 > 10)
 Number of child tables: 1 (Use \d+ to list them.)
+Distributed by: (ff1)
 
 \d c1
       Table "public.c1"
@@ -724,6 +634,7 @@ Number of child tables: 1 (Use \d+ to list them.)
 Check constraints:
     "p2chk" CHECK (ff1 > 10)
 Inherits: p1
+Distributed by: (ff1)
 
 drop table p1 cascade;
 NOTICE:  drop cascades to table c1
@@ -742,6 +653,8 @@ drop table derived;
 drop table base;
 create table p1(ff1 int);
 create table p2(f1 text);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'f1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 create function p2text(p2) returns text as 'select $1.f1' language sql;
 create table c1(f3 int) inherits(p1,p2);
 insert into c1 values(123456789, 'hi', 42);
@@ -893,6 +806,7 @@ Check constraints:
     "p2_f2_check" CHECK (f2 > 0)
 Inherits: p1,
           p2
+Distributed by: (f1)
 
 create table c3 (f4 int) inherits(c1,c2);
 NOTICE:  merging multiple inherited definitions of column "f1"
@@ -910,6 +824,7 @@ Check constraints:
     "p2_f2_check" CHECK (f2 > 0)
 Inherits: c1,
           c2
+Distributed by: (f1)
 
 drop table p1 cascade;
 NOTICE:  drop cascades to 3 other objects
@@ -931,6 +846,7 @@ alter table pp1 add column a1 int check (a1 > 0);
 Check constraints:
     "pp1_a1_check" CHECK (a1 > 0)
 Inherits: pp1
+Distributed by: (f1)
 
 create table cc2(f4 float) inherits(pp1,cc1);
 NOTICE:  merging multiple inherited definitions of column "f1"
@@ -948,6 +864,7 @@ Check constraints:
     "pp1_a1_check" CHECK (a1 > 0)
 Inherits: pp1,
           cc1
+Distributed by: (f1)
 
 alter table pp1 add column a2 int check (a2 > 0);
 NOTICE:  merging definition of column "a2" for child "cc2"
@@ -967,6 +884,7 @@ Check constraints:
     "pp1_a2_check" CHECK (a2 > 0)
 Inherits: pp1,
           cc1
+Distributed by: (f1)
 
 drop table pp1 cascade;
 NOTICE:  drop cascades to 2 other objects
@@ -994,6 +912,7 @@ ALTER TABLE inhts RENAME d TO dd;
 Inherits: inht1,
           inhs1
 Has OIDs: no
+Distributed by: (aa)
 
 DROP TABLE inhts;
 -- Test for renaming in diamond inheritance
@@ -1015,6 +934,7 @@ ALTER TABLE inht1 RENAME aa TO aaa;
 Inherits: inht2,
           inht3
 Has OIDs: no
+Distributed by: (aaa)
 
 CREATE TABLE inhts (d int) INHERITS (inht2, inhs1);
 NOTICE:  merging multiple inherited definitions of column "b"
@@ -1033,6 +953,7 @@ ERROR:  cannot rename inherited column "b"
 Inherits: inht2,
           inhs1
 Has OIDs: no
+Distributed by: (aaaa)
 
 WITH RECURSIVE r AS (
   SELECT 'inht1'::regclass AS inhrelid
@@ -1083,23 +1004,31 @@ create index patest2i on patest2(id);
 analyze patest0;
 analyze patest1;
 analyze patest2;
+set enable_seqscan=off;
 explain (costs off)
-select * from patest0 join (select f1 from int4_tbl limit 1) ss on id = f1;
-                        QUERY PLAN                        
-----------------------------------------------------------
- Nested Loop
-   ->  Limit
-         ->  Seq Scan on int4_tbl
-   ->  Append
-         ->  Index Scan using patest0i on patest0
-               Index Cond: (id = int4_tbl.f1)
-         ->  Index Scan using patest1i on patest1 patest0
-               Index Cond: (id = int4_tbl.f1)
-         ->  Index Scan using patest2i on patest2 patest0
-               Index Cond: (id = int4_tbl.f1)
-(10 rows)
+select * from patest0 join (select f1 from int4_tbl where f1 < 10 and f1 > -10 limit 1) ss on id = f1;
+                                 QUERY PLAN                                 
+----------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)
+   ->  Hash Join
+         Hash Cond: pg_temp_459.patest0.id = int4_tbl.f1
+         ->  Merge Append
+               Sort Key: pg_temp_459.patest0.id
+               ->  Index Scan using patest0i on patest0
+               ->  Index Scan using patest1i on patest1 patest0
+               ->  Index Scan using patest2i on patest2 patest0
+         ->  Hash
+               ->  Redistribute Motion 1:3  (slice2; segments: 1)
+                     Hash Key: int4_tbl.f1
+                     ->  Limit
+                           ->  Gather Motion 3:1  (slice1; segments: 3)
+                                 ->  Limit
+                                       ->  Seq Scan on int4_tbl
+                                             Filter: f1 < 10 AND f1 > (-10)
+ Optimizer: legacy query optimizer
+(16 rows)
 
-select * from patest0 join (select f1 from int4_tbl limit 1) ss on id = f1;
+select * from patest0 join (select f1 from int4_tbl where f1 < 10 and f1 > -10 limit 1) ss on id = f1;
  id | x | f1 
 ----+---+----
   0 | 0 |  0
@@ -1109,22 +1038,30 @@ select * from patest0 join (select f1 from int4_tbl limit 1) ss on id = f1;
 
 drop index patest2i;
 explain (costs off)
-select * from patest0 join (select f1 from int4_tbl limit 1) ss on id = f1;
-                        QUERY PLAN                        
-----------------------------------------------------------
- Nested Loop
-   ->  Limit
-         ->  Seq Scan on int4_tbl
-   ->  Append
-         ->  Index Scan using patest0i on patest0
-               Index Cond: (id = int4_tbl.f1)
-         ->  Index Scan using patest1i on patest1 patest0
-               Index Cond: (id = int4_tbl.f1)
-         ->  Seq Scan on patest2 patest0
-               Filter: (int4_tbl.f1 = id)
-(10 rows)
+select * from patest0 join (select f1 from int4_tbl where f1 < 10 and f1 > -10 limit 1) ss on id = f1;
+                                 QUERY PLAN                                 
+----------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)
+   ->  Hash Join
+         Hash Cond: pg_temp_665.patest0.id = int4_tbl.f1
+         ->  Append
+               ->  Bitmap Heap Scan on patest0
+                     ->  Bitmap Index Scan on patest0i
+               ->  Bitmap Heap Scan on patest1 patest0
+                     ->  Bitmap Index Scan on patest1i
+               ->  Seq Scan on patest2 patest0
+         ->  Hash
+               ->  Redistribute Motion 1:3  (slice2; segments: 1)
+                     Hash Key: int4_tbl.f1
+                     ->  Limit
+                           ->  Gather Motion 3:1  (slice1; segments: 3)
+                                 ->  Limit
+                                       ->  Seq Scan on int4_tbl
+                                             Filter: f1 < 10 AND f1 > (-10)
+ Optimizer: legacy query optimizer
+(17 rows)
 
-select * from patest0 join (select f1 from int4_tbl limit 1) ss on id = f1;
+select * from patest0 join (select f1 from int4_tbl where f1 < 10 and f1 > -10 limit 1) ss on id = f1;
  id | x | f1 
 ----+---+----
   0 | 0 |  0
@@ -1132,6 +1069,7 @@ select * from patest0 join (select f1 from int4_tbl limit 1) ss on id = f1;
   0 | 0 |  0
 (3 rows)
 
+reset enable_seqscan;
 drop table patest0 cascade;
 NOTICE:  drop cascades to 2 other objects
 DETAIL:  drop cascades to table patest1
@@ -1163,23 +1101,28 @@ insert into matest3 (name) values ('Test 5');
 insert into matest3 (name) values ('Test 6');
 set enable_indexscan = off;  -- force use of seqscan/sort, so no merge
 explain (verbose, costs off) select * from matest0 order by 1-id;
-                                   QUERY PLAN                                    
----------------------------------------------------------------------------------
- Sort
+                                      QUERY PLAN                                       
+---------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
    Output: public.matest0.id, public.matest0.name, ((1 - public.matest0.id))
-   Sort Key: ((1 - public.matest0.id))
-   ->  Result
-         Output: public.matest0.id, public.matest0.name, (1 - public.matest0.id)
-         ->  Append
-               ->  Seq Scan on public.matest0
-                     Output: public.matest0.id, public.matest0.name
-               ->  Seq Scan on public.matest1 matest0
-                     Output: public.matest0.id, public.matest0.name
-               ->  Seq Scan on public.matest2 matest0
-                     Output: public.matest0.id, public.matest0.name
-               ->  Seq Scan on public.matest3 matest0
-                     Output: public.matest0.id, public.matest0.name
-(14 rows)
+   Merge Key: (1 - public.matest0.id)
+   ->  Sort
+         Output: public.matest0.id, public.matest0.name, ((1 - public.matest0.id))
+         Sort Key: (1 - public.matest0.id)
+         ->  Result
+               Output: public.matest0.id, public.matest0.name, (1 - public.matest0.id)
+               ->  Append
+                     ->  Seq Scan on public.matest0
+                           Output: public.matest0.id, public.matest0.name
+                     ->  Seq Scan on public.matest1 matest0
+                           Output: public.matest0.id, public.matest0.name
+                     ->  Seq Scan on public.matest2 matest0
+                           Output: public.matest0.id, public.matest0.name
+                     ->  Seq Scan on public.matest3 matest0
+                           Output: public.matest0.id, public.matest0.name
+ Optimizer: legacy query optimizer
+ Settings: enable_indexscan=off
+(19 rows)
 
 select * from matest0 order by 1-id;
  id |  name  

--- a/src/test/regress/expected/select_into.out
+++ b/src/test/regress/expected/select_into.out
@@ -90,11 +90,7 @@ LINE 1: SELECT * FROM (SELECT 1 INTO f) bar;
                                      ^
 CREATE VIEW foo AS SELECT 1 INTO b;
 ERROR:  views must not contain SELECT INTO
--- pg upstream uses table b which was created in inherit test, however that test
--- is disabled for unknown reason so I'm creating a new table for temp use.
-CREATE TABLE b (bb TEXT) DISTRIBUTED BY (bb);
 INSERT INTO b SELECT 1 INTO f;
 ERROR:  SELECT ... INTO is not allowed here
 LINE 1: INSERT INTO b SELECT 1 INTO f;
                                     ^
-DROP TABLE b;

--- a/src/test/regress/output/misc.source
+++ b/src/test/regress/output/misc.source
@@ -525,6 +525,8 @@ SELECT user_relns() AS user_relns
  __gp_user_data_tables_readable
  __gp_user_namespaces
  __gp_user_tables
+ a
+ a_dummy_seq
  a_star
  abstime_tbl
  aggtest
@@ -532,6 +534,7 @@ SELECT user_relns() AS user_relns
  array_index_op_test
  array_op_test
  arrtest
+ b
  b_star
  box_tbl
  bprime
@@ -539,6 +542,7 @@ SELECT user_relns() AS user_relns
  bt_i4_heap
  bt_name_heap
  bt_txt_heap
+ c
  c_star
  char_tbl
  check2_tbl
@@ -547,6 +551,7 @@ SELECT user_relns() AS user_relns
  circle_tbl
  city
  copy_tbl
+ d
  d_star
  date_tbl
  default_seq
@@ -675,7 +680,7 @@ SELECT user_relns() AS user_relns
  toyemp
  usr_define_type
  varchar_tbl
-(160 rows)
+(165 rows)
 
 SELECT name(equipment(hobby_construct(text 'skywalking', text 'mer')));
  name 

--- a/src/test/regress/sql/inherit.sql
+++ b/src/test/regress/sql/inherit.sql
@@ -163,7 +163,7 @@ drop table base;
 
 create table p1(ff1 int);
 create table p2(f1 text);
-create function p2text(p2) returns text as 'select $1.f1' language sql CONTAINS SQL;
+create function p2text(p2) returns text as 'select $1.f1' language sql;
 create table c1(f3 int) inherits(p1,p2);
 insert into c1 values(123456789, 'hi', 42);
 select p2text(c1.*) from c1;
@@ -310,15 +310,17 @@ analyze patest0;
 analyze patest1;
 analyze patest2;
 
+set enable_seqscan=off;
 explain (costs off)
-select * from patest0 join (select f1 from int4_tbl limit 1) ss on id = f1;
-select * from patest0 join (select f1 from int4_tbl limit 1) ss on id = f1;
+select * from patest0 join (select f1 from int4_tbl where f1 < 10 and f1 > -10 limit 1) ss on id = f1;
+select * from patest0 join (select f1 from int4_tbl where f1 < 10 and f1 > -10 limit 1) ss on id = f1;
 
 drop index patest2i;
 
 explain (costs off)
-select * from patest0 join (select f1 from int4_tbl limit 1) ss on id = f1;
-select * from patest0 join (select f1 from int4_tbl limit 1) ss on id = f1;
+select * from patest0 join (select f1 from int4_tbl where f1 < 10 and f1 > -10 limit 1) ss on id = f1;
+select * from patest0 join (select f1 from int4_tbl where f1 < 10 and f1 > -10 limit 1) ss on id = f1;
+reset enable_seqscan;
 
 drop table patest0 cascade;
 

--- a/src/test/regress/sql/select_into.sql
+++ b/src/test/regress/sql/select_into.sql
@@ -75,8 +75,4 @@ DECLARE foo CURSOR FOR SELECT 1 INTO b;
 COPY (SELECT 1 INTO frak UNION SELECT 2) TO 'blob';
 SELECT * FROM (SELECT 1 INTO f) bar;
 CREATE VIEW foo AS SELECT 1 INTO b;
--- pg upstream uses table b which was created in inherit test, however that test
--- is disabled for unknown reason so I'm creating a new table for temp use.
-CREATE TABLE b (bb TEXT) DISTRIBUTED BY (bb);
 INSERT INTO b SELECT 1 INTO f;
-DROP TABLE b;


### PR DESCRIPTION
create table t(c1 int);
create table th(c1 int) inherits (t);
drop table t, th;

The drop statement works on master but fails on segments, which is
not the same as upstream.
In GPDB, master can find 'th' depends on 't' so it deletes the two relations
in performMultipleDeletions, but it dispatches two different drop commands
for table 't' and 'th' to segment, and segment can't drop 't' because it has
depend object.