### PR TITLE
Allow direct dispatch for index only scan.

### DIFF
--- a/src/backend/cdb/cdbtargeteddispatch.c
+++ b/src/backend/cdb/cdbtargeteddispatch.c
@@ -553,7 +553,7 @@ AssignContentIdsToPlanData_Walker(Node *node, void *context)
 					dispatchInfo = GetContentIdsFromPlanForSingleRelation(data->rtable,
 																		 (Plan *) node,
 																		 ((Scan *) node)->scanrelid,
-																		 (Node *) indexOnlyScan->indexqual);
+																		 (Node *) indexOnlyScan->indexqualorig);
 					/* must use _orig_ qual ! */
 				}
 				break;

--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -634,6 +634,7 @@ _copyIndexOnlyScan(const IndexOnlyScan *from)
 	 */
 	COPY_SCALAR_FIELD(indexid);
 	COPY_NODE_FIELD(indexqual);
+	COPY_NODE_FIELD(indexqualorig);
 	COPY_NODE_FIELD(indexorderby);
 	COPY_NODE_FIELD(indextlist);
 	COPY_SCALAR_FIELD(indexorderdir);

--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -141,7 +141,8 @@ static IndexScan *make_indexscan(List *qptlist, List *qpqual, Index scanrelid,
 			   ScanDirection indexscandir);
 static IndexOnlyScan *make_indexonlyscan(List *qptlist, List *qpqual,
 				   Index scanrelid, Oid indexid,
-				   List *indexqual, List *indexorderby,
+				   List *indexqual, List *indexqualorig,
+				   List *indexorderby,
 				   List *indextlist,
 				   ScanDirection indexscandir);
 static BitmapIndexScan *make_bitmap_indexscan(Index scanrelid, Oid indexid,
@@ -2307,8 +2308,9 @@ create_indexscan_plan(PlannerInfo *root,
 												baserelid,
 												indexoid,
 												fixed_indexquals,
+												stripped_indexquals,
 												fixed_indexorderbys,
-											best_path->indexinfo->indextlist,
+												best_path->indexinfo->indextlist,
 												best_path->indexscandir);
 	else
 		scan_plan = (Scan *) make_indexscan(tlist,
@@ -4576,6 +4578,7 @@ make_indexonlyscan(List *qptlist,
 				   Index scanrelid,
 				   Oid indexid,
 				   List *indexqual,
+				   List *indexqualorig,
 				   List *indexorderby,
 				   List *indextlist,
 				   ScanDirection indexscandir)
@@ -4591,6 +4594,7 @@ make_indexonlyscan(List *qptlist,
 	node->scan.scanrelid = scanrelid;
 	node->indexid = indexid;
 	node->indexqual = indexqual;
+	node->indexqualorig = indexqualorig;
 	node->indexorderby = indexorderby;
 	node->indextlist = indextlist;
 	node->indexorderdir = indexscandir;

--- a/src/backend/optimizer/plan/setrefs.c
+++ b/src/backend/optimizer/plan/setrefs.c
@@ -1210,6 +1210,8 @@ set_indexonlyscan_references(PlannerInfo *root,
 					   rtoffset);
 	/* indexqual is already transformed to reference index columns */
 	plan->indexqual = fix_scan_list(root, plan->indexqual, rtoffset);
+	/* indexqualorig is already transformed to reference index columns */
+	plan->indexqualorig = fix_scan_list(root, plan->indexqualorig, rtoffset);
 	/* indexorderby is already transformed to reference index columns */
 	plan->indexorderby = fix_scan_list(root, plan->indexorderby, rtoffset);
 	/* indextlist must NOT be transformed to reference index columns */

--- a/src/include/nodes/plannodes.h
+++ b/src/include/nodes/plannodes.h
@@ -583,6 +583,9 @@ typedef struct DynamicIndexScan
  * with one TLE per index column.  Vars appearing in this list reference
  * the base table, and this is the only field in the plan node that may
  * contain such Vars.
+ *
+ * GPDB: We need indexqualorig to determine direct dispatch, however there
+ * is no need to dispatch it.
  * ----------------
  */
 typedef struct IndexOnlyScan
@@ -590,6 +593,7 @@ typedef struct IndexOnlyScan
 	Scan		scan;
 	Oid			indexid;		/* OID of index to scan */
 	List	   *indexqual;		/* list of index quals (usually OpExprs) */
+	List	   *indexqualorig;	/* the same in original form (GPDB keeps it) */
 	List	   *indexorderby;	/* list of index ORDER BY exprs */
 	List	   *indextlist;		/* TargetEntry list describing index's cols */
 	ScanDirection indexorderdir;	/* forward or backward or don't care */

--- a/src/test/regress/expected/create_index.out
+++ b/src/test/regress/expected/create_index.out
@@ -1067,7 +1067,7 @@ SELECT count(*) FROM suffix_text_tbl WHERE t = 'P0123456789abcdef';
                                QUERY PLAN                               
 ------------------------------------------------------------------------
  Aggregate
-   ->  Gather Motion 3:1  (slice1; segments: 3)
+   ->  Gather Motion 1:1  (slice1; segments: 1)
          ->  Aggregate
                ->  Index Only Scan using sp_suff_ind on suffix_text_tbl
                      Index Cond: t = 'P0123456789abcdef'::text
@@ -1085,7 +1085,7 @@ SELECT count(*) FROM suffix_text_tbl WHERE t = 'P0123456789abcde';
                                QUERY PLAN                               
 ------------------------------------------------------------------------
  Aggregate
-   ->  Gather Motion 3:1  (slice1; segments: 3)
+   ->  Gather Motion 1:1  (slice1; segments: 1)
          ->  Aggregate
                ->  Index Only Scan using sp_suff_ind on suffix_text_tbl
                      Index Cond: t = 'P0123456789abcde'::text
@@ -1103,7 +1103,7 @@ SELECT count(*) FROM suffix_text_tbl WHERE t = 'P0123456789abcdefF';
                                QUERY PLAN                               
 ------------------------------------------------------------------------
  Aggregate
-   ->  Gather Motion 3:1  (slice1; segments: 3)
+   ->  Gather Motion 1:1  (slice1; segments: 1)
          ->  Aggregate
                ->  Index Only Scan using sp_suff_ind on suffix_text_tbl
                      Index Cond: t = 'P0123456789abcdefF'::text
@@ -1193,7 +1193,7 @@ SELECT count(*) FROM suffix_text_tbl WHERE t =    'Aztec                        
                                    QUERY PLAN                                   
 --------------------------------------------------------------------------------
  Aggregate
-   ->  Gather Motion 3:1  (slice1; segments: 3)
+   ->  Gather Motion 1:1  (slice1; segments: 1)
          ->  Aggregate
                ->  Index Only Scan using sp_suff_ind on suffix_text_tbl
                      Index Cond: t = 'Aztec                         Ct  '::text
@@ -1211,7 +1211,7 @@ SELECT count(*) FROM suffix_text_tbl WHERE t =    'Worth                        
                                    QUERY PLAN                                   
 --------------------------------------------------------------------------------
  Aggregate
-   ->  Gather Motion 3:1  (slice1; segments: 3)
+   ->  Gather Motion 1:1  (slice1; segments: 1)
          ->  Aggregate
                ->  Index Only Scan using sp_suff_ind on suffix_text_tbl
                      Index Cond: t = 'Worth                         St  '::text


### PR DESCRIPTION
Normally for index only scan, indexqualorig is not needed, however to check direct dispatch, we still need this. In executor this variable is not needed any more so we do not dispatch it.