### PR TITLE
Fix GDD under fastpath.

### DIFF
--- a/src/include/storage/proc.h
+++ b/src/include/storage/proc.h
@@ -185,6 +185,7 @@ struct PGPROC
 
 	/* Lock manager data, recording fast-path locks taken by this backend. */
 	uint64		fpLockBits;		/* lock modes held for each fast-path slot */
+	uint64		fpHoldTillEndXactBits;	/* HoldTillEndXactBits for each slot */
 	Oid			fpRelId[FP_LOCK_SLOTS_PER_BACKEND];		/* slots for rel oids */
 	bool		fpVXIDLock;		/* are we holding a fast-path VXID lock? */
 	LocalTransactionId fpLocalTransactionId;	/* lxid for fast-path VXID

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -1,8 +1,8 @@
 test: select_for_update
-#test for global distributed deadlock detector
-#test: gdd/prepare
-#test: gdd/dist-deadlock-01 gdd/dist-deadlock-04 gdd/dist-deadlock-05 gdd/dist-deadlock-06 gdd/dist-deadlock-07 gdd/dist-deadlock-102 gdd/dist-deadlock-103 gdd/dist-deadlock-104 gdd/dist-deadlock-106 gdd/local-deadlock-03 gdd/non-lock-105 gdd/non-lock-107
-#test: gdd/avoid-qd-deadlock
+# test for global distributed deadlock detector
+test: gdd/prepare
+test: gdd/dist-deadlock-01 gdd/dist-deadlock-04 gdd/dist-deadlock-05 gdd/dist-deadlock-06 gdd/dist-deadlock-07 gdd/dist-deadlock-102 gdd/dist-deadlock-103 gdd/dist-deadlock-104 gdd/dist-deadlock-106 gdd/local-deadlock-03 gdd/non-lock-105 gdd/non-lock-107
+test: gdd/avoid-qd-deadlock
 
 test: pg_terminate_backend deadlock_under_entry_db_singleton starve_case pg_views_concurrent_drop alter_blocks_for_update_and_viceversa drop_rename reader_waits_for_lock resource_queue
 


### PR DESCRIPTION
With 9.2 merge fastpath is add, GDD is disable temporarily as it cannot properly
recognize all locks with fastpath.

In the function set the HoldTillEndXact field, locallock->lock might be NULL if
the lock is held via fast path.

In this commit, I add a field fpHoldTillEndXact(like fpRelId) in PROC struct to save this
info.