### PR TITLE
Set rows variable correctly for some code path.

### DIFF
--- a/src/backend/optimizer/plan/planmain.c
+++ b/src/backend/optimizer/plan/planmain.c
@@ -434,6 +434,7 @@ query_planner(PlannerInfo *root, List *tlist,
 					  cheapestpath->total_cost,
 					  cdbpath_rows(root, cheapestpath), final_rel->width,
 					  0.0, work_mem, limit_tuples);
+			sort_path.rows = final_rel->rows;
 		}
 
 		if (compare_fractional_path_costs(sortedpath, &sort_path,

--- a/src/backend/optimizer/util/pathnode.c
+++ b/src/backend/optimizer/util/pathnode.c
@@ -1709,6 +1709,7 @@ create_material_path(PlannerInfo *root, RelOptInfo *rel, Path *subpath)
 				  subpath->total_cost,
 				  cdbpath_rows(root, subpath),
 				  rel->width);
+	pathnode->path.rows = subpath->rows;
 
 	return pathnode;
 }

--- a/src/backend/optimizer/util/relnode.c
+++ b/src/backend/optimizer/util/relnode.c
@@ -1127,8 +1127,8 @@ get_joinrel_parampathinfo(PlannerInfo *root, RelOptInfo *joinrel,
 
 	/* Estimate the number of rows returned by the parameterized join */
 	rows = get_parameterized_joinrel_size(root, joinrel,
-										  cdbpath_rows(root, outer_path),
-										  cdbpath_rows(root, inner_path),
+										  outer_path->rows,
+										  inner_path->rows,
 										  sjinfo,
 										  *restrict_clauses);
 

--- a/src/include/cdb/cdbpath.h
+++ b/src/include/cdb/cdbpath.h
@@ -54,7 +54,10 @@ cdbpath_rows(PlannerInfo *root, Path *path)
 {
 	/* GPDB_92_MERGE_FIXME: Maybe we should think about removing this function.
 	 * That will eliminate merge risk since pg upstream (since 9.2) uses
-	 * path->rows directly.
+	 * path->rows directly. Besides, it seems that this function should be
+	 * for cost estimation only but rows variable setting is often mixed with cost
+	 * estimation in pg/gp code, e.g. cost_material(), so we have to ugly reset
+	 * rows sometimes: See query_planner() and create_material_path().
 	 */
 	Path  *p;
 


### PR DESCRIPTION
It seems that cdbpath_rows() should be used for cost estimation only
however it is often called to set rows also. We should be very
careful on this. In the long run we should decouple cost estimation
and rows variable setting. That is to say, remove the ugly hack function
cdbpath_rows() and its use.