### PR TITLE
Change usages of gpdb_master-ci-secrets.yml to use .prod suffix

### DIFF
--- a/concourse/pipelines/README.md
+++ b/concourse/pipelines/README.md
@@ -88,8 +88,8 @@ fly -t gpdb-prod \
     set-pipeline \
     -p gpdb_master \
     -c gpdb_master-generated.yml \
-    -l ~/workspace/continuous-integration/secrets/gpdb_common-ci-secrets.yml \
-    -l ~/workspace/continuous-integration/secrets/gpdb_master-ci-secrets.yml
+    -l ~/workspace/gp-continuous-integration/secrets/gpdb_common-ci-secrets.yml \
+    -l ~/workspace/gp-continuous-integration/secrets/gpdb_master-ci-secrets.prod.yml
 
 fly -t gpdb-prod \
     set-pipeline \

--- a/concourse/pipelines/gen_pipeline.py
+++ b/concourse/pipelines/gen_pipeline.py
@@ -132,8 +132,8 @@ def how_to_use_generated_pipeline_message():
         msg += '    set-pipeline \\\n'
         msg += '    -p gpdb_master \\\n'
         msg += '    -c %s \\\n' % ARGS.output_filepath
-        msg += '    -l ~/workspace/continuous-integration/secrets/gpdb_common-ci-secrets.yml \\\n'
-        msg += '    -l ~/workspace/continuous-integration/secrets/gpdb_master-ci-secrets.yml\n\n'
+        msg += '    -l ~/workspace/gp-continuous-integration/secrets/gpdb_common-ci-secrets.yml \\\n'
+        msg += '    -l ~/workspace/gp-continuous-integration/secrets/gpdb_master-ci-secrets.prod.yml\n\n'
         msg += 'fly -t gpdb-prod \\\n'
         msg += '    set-pipeline \\\n'
         msg += '    -p gpdb_master_without_asserts \\\n'
@@ -147,7 +147,7 @@ def how_to_use_generated_pipeline_message():
         msg += '    -p %s \\\n' % os.path.basename(ARGS.output_filepath).rsplit('.', 1)[0]
         msg += '    -c %s \\\n' % ARGS.output_filepath
         msg += '    -l ~/workspace/continuous-integration/secrets/gpdb_common-ci-secrets.yml \\\n'
-        msg += '    -l ~/workspace/continuous-integration/secrets/gpdb_master-ci-secrets.yml \\\n'
+        msg += '    -l ~/workspace/continuous-integration/secrets/gpdb_master-ci-secrets.dev.yml \\\n'
         msg += '    -l ~/workspace/continuous-integration/secrets/ccp_ci_secrets_gpdb-dev.yml \\\n'
         msg += '    -v bucket-name=gpdb5-concourse-builds-dev \\\n'
         msg += '    -v gpdb-git-remote=<https://github.com/<github-user>/gpdb> \\\n'


### PR DESCRIPTION
We are in the process of renaming the secrets files in
gp-continuous-integration to use the .prod suffix consistently.

See the related PR in GPDB: https://github.com/greenplum-db/gpdb/pull/7099

Co-authored-by: Ben Christel <bchristel@pivotal.io>
Co-authored-by: Sambitesh Dash <sdash@pivotal.io>