### PR TITLE
Remove MERGE_FIXME of _outExtensibleNode

### DIFF
--- a/src/backend/executor/nodeModifyTable.c
+++ b/src/backend/executor/nodeModifyTable.c
@@ -143,7 +143,7 @@ ExecCheckPlanOutput(Relation resultRel, List *targetList)
 			 * What we insist on is just *some* NULL constant.
 			 */
 			/* GPDB_96_MERGE_FIXME: the subplan can be a Motion, so that the NULLs
-			 * are transferred throught he Motion node.
+			 * are transferred through the Motion node.
 			 */
 #if 0
 			if (!IsA(tle->expr, Const) ||

--- a/src/backend/nodes/nodeFuncs.c
+++ b/src/backend/nodes/nodeFuncs.c
@@ -3914,7 +3914,7 @@ planstate_tree_walker(PlanState *planstate,
 									   walker, context))
 				return true;
 			break;
-		/* GPDB_96_MERGE_FIXME: verify walkder works on Sequence node */
+		/* GPDB_96_MERGE_FIXME: verify walker works on Sequence node */
 		case T_Sequence:
 			if (planstate_walk_members(((Sequence *) plan)->subplans,
 								  ((SequenceState *) planstate)->subplans,

--- a/src/backend/nodes/outfast.c
+++ b/src/backend/nodes/outfast.c
@@ -108,7 +108,7 @@
 #define WRITE_STRING_VAR(var) \
 	{ int slen = var != NULL ? strlen(var) : 0; \
 		appendBinaryStringInfo(str, (const char *)&slen, sizeof(int)); \
-		if (slen>0) appendBinaryStringInfo(str, var, strlen(var));}
+		if (slen>0) appendBinaryStringInfo(str, var, slen);}
 
 /* Write a character-string (possibly NULL) field */
 #define WRITE_STRING_FIELD(fldname)  WRITE_STRING_VAR(node->fldname)
@@ -600,6 +600,7 @@ _outExtensibleNode(StringInfo str, const ExtensibleNode *node)
 {
 	const ExtensibleNodeMethods *methods;
 	StringInfoData buf;
+	initStringInfo(&buf);
 
 	methods = GetExtensibleNodeMethods(node->extnodename, false);
 

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -2965,7 +2965,6 @@ _outPlannerParamItem(StringInfo str, const PlannerParamItem *node)
  *
  *****************************************************************************/
 
-/* GPDB_96_MERGE_FIXME: I think we'd need outfast/readfast support for this */
 #ifndef COMPILING_BINARY_FUNCS
 static void
 _outExtensibleNode(StringInfo str, const ExtensibleNode *node)

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -2819,7 +2819,6 @@ _outDistributionKey(StringInfo str, const DistributionKey *node)
 	WRITE_OID_FIELD(dk_opfamily);
 }
 
-#ifndef COMPILING_BINARY_FUNCS
 static void
 _outPathTarget(StringInfo str, const PathTarget *node)
 {
@@ -2838,9 +2837,7 @@ _outPathTarget(StringInfo str, const PathTarget *node)
 	WRITE_FLOAT_FIELD(cost.per_tuple, "%.2f");
 	WRITE_INT_FIELD(width);
 }
-#endif /* COMPILING_BINARY_FUNCS */
 
-#ifndef COMPILING_BINARY_FUNCS
 static void
 _outParamPathInfo(StringInfo str, const ParamPathInfo *node)
 {
@@ -2850,7 +2847,6 @@ _outParamPathInfo(StringInfo str, const ParamPathInfo *node)
 	WRITE_FLOAT_FIELD(ppi_rows, "%.0f");
 	WRITE_NODE_FIELD(ppi_clauses);
 }
-#endif /* COMPILING_BINARY_FUNCS */
 
 static void
 _outRestrictInfo(StringInfo str, const RestrictInfo *node)

--- a/src/backend/nodes/read.c
+++ b/src/backend/nodes/read.c
@@ -34,6 +34,19 @@ static char *pg_strtok_begin = NULL;                    /*CDB*/
 
 static void nodeReadSkipThru(char closingDelimiter);    /*CDB*/
 
+void
+save_strtok_states(char **save_ptr, char **save_begin)
+{
+	*save_ptr = pg_strtok_ptr;		/* point pg_strtok at the string to read */
+	*save_begin = pg_strtok_begin;	/* CDB: save starting position for debug */
+}
+
+void
+set_strtok_states(char *ptr, char *begin)
+{
+	pg_strtok_ptr = ptr;		/* point pg_strtok at the string to read */
+	pg_strtok_begin = begin;	/* CDB: save starting position for debug */
+}
 
 /*
  * stringToNode -

--- a/src/backend/nodes/read.c
+++ b/src/backend/nodes/read.c
@@ -34,6 +34,7 @@ static char *pg_strtok_begin = NULL;                    /*CDB*/
 
 static void nodeReadSkipThru(char closingDelimiter);    /*CDB*/
 
+/* Helper functions for saving current states and pg_strtok() another string */
 void
 save_strtok_states(char **save_ptr, char **save_begin)
 {

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -24,6 +24,9 @@
  * block, and readfast.c provides the binary version of the function.
  * outfast.c and outfuncs.c have a similar relationship.
  *
+ * By this, CDB could link only readfast.o (#includes readfuncs.c) to get all
+ * the fast version deserializing functions, outfast.o likewise.
+ *
  *-------------------------------------------------------------------------
  */
 #include "postgres.h"
@@ -1055,8 +1058,10 @@ _readExtensibleNode(void)
 	const char *extnodename;
 
 	char *str;
-	char **save_strtok = NULL;
-	char **save_begin = NULL;
+	char *save_strtok = NULL;
+	char *save_begin = NULL;
+	char **save_strtok_ptr = &save_strtok;
+	char **save_begin_ptr = &save_begin;
 
 	READ_STRING_VAR(extnodename);
 	if (!extnodename)
@@ -1074,14 +1079,14 @@ _readExtensibleNode(void)
 	 */
 
 	/* set the states for pg_strtok(), let methods->nodeRead() to process str */
-	save_strtok_states(save_strtok, save_begin);
+	save_strtok_states(save_strtok_ptr, save_begin_ptr);
 	set_strtok_states(str, str);
 
 	/* do reading */
 	methods->nodeRead(local_node);
 
 	/* set the states for pg_strtok() back */
-	set_strtok_states(*save_strtok, *save_begin);
+	set_strtok_states(save_strtok, save_begin);
 
 	READ_DONE();
 }

--- a/src/include/nodes/nodes.h
+++ b/src/include/nodes/nodes.h
@@ -733,6 +733,8 @@ extern Node *readNodeFromBinaryString(const char *str, int len);
 /*
  * nodes/{readfuncs.c,read.c}
  */
+extern void save_strtok_states(char **save_ptr, char **save_begin);
+extern void set_strtok_states(char *ptr, char *begin);
 extern void *stringToNode(char *str);
 extern struct Bitmapset *readBitmapset(void);
 extern int64 readDatum(bool typbyval);


### PR DESCRIPTION
An extensible node is a new type of node defined by an extension, its
serialization and deserialization functions nodeOut() and nodeRead() are
provided by the extension.

Implement the fast versions of _outExtensibleNode() and
_readExtensibleNode(), which use a trick to leverage the extension's
nodeOut() and nodeRead().

```
/*
 * node_size is the size of an extensible node of this type in bytes.
 *
 * nodeCopy is a function which performs a deep copy from oldnode to newnode.
 * It does not need to copy type or extnodename, which are copied by the
 * core system.
 *
 * nodeEqual is a function which performs a deep equality comparison between
 * a and b and returns true or false accordingly.  It does not need to compare
 * type or extnodename, which are compared by the core system.
 *
 * nodeOut is a serialization function for the node type.  It should use the
 * output conventions typical for outfuncs.c.  It does not need to output
 * type or extnodename; the core system handles those.
 *
 * nodeRead is a deserialization function for the node type.  It does not need
 * to read type or extnodename; the core system handles those.  It should fetch
 * the next token using pg_strtok() from the current input stream, and then
 * reconstruct the private fields according to the manner in readfuncs.c.
 *
 * All callbacks are mandatory.
 */
typedef struct ExtensibleNodeMethods
{
    const char *extnodename;
    Size        node_size;
    void        (*nodeCopy) (struct ExtensibleNode *newnode,
                                       const struct ExtensibleNode *oldnode);
    bool        (*nodeEqual) (const struct ExtensibleNode *a,
                                          const struct ExtensibleNode *b);
    void        (*nodeOut) (struct StringInfoData *str,
                                        const struct ExtensibleNode *node);
    void        (*nodeRead) (struct ExtensibleNode *node);
} ExtensibleNodeMethods;
```
