### PR TITLE
pg_ctl -w should wait for distributed transaction recovery

### DIFF
--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -3679,6 +3679,14 @@ CleanupBackgroundWorker(int pid,
 			/* Zero exit status means terminate */
 			rw->rw_crashed_at = 0;
 			rw->rw_terminate = true;
+
+			/* dtx recovery completed successfully */
+			if (rw->rw_worker.bgw_start_rule == DtxRecoveryStartRule)
+			{
+				Assert(strcmp(rw->rw_worker.bgw_name, "dtx recovery process") == 0);
+				Assert(*shmDtmStarted);
+				AddToDataDirLockFile(LOCK_FILE_LINE_PM_STATUS, PM_STATUS_DTM_RECOVERED);
+			}
 		}
 
 		/*

--- a/src/bin/pg_ctl/pg_ctl.c
+++ b/src/bin/pg_ctl/pg_ctl.c
@@ -574,6 +574,13 @@ static WaitPMResult
 wait_for_postmaster(pgpid_t pm_pid, bool do_checkpoint)
 {
 	int			i;
+	bool gpdb_master_distributed_mode;
+
+	/* check if starting GPDB master in distributed mode */
+	if (strstr(post_opts, "-E"))
+		gpdb_master_distributed_mode = true;
+	else
+		gpdb_master_distributed_mode = false;
 
 	for (i = 0; i < wait_seconds * WAITS_PER_SEC; i++)
 	{
@@ -615,7 +622,7 @@ wait_for_postmaster(pgpid_t pm_pid, bool do_checkpoint)
 				 */
 				char	   *pmstatus = optlines[LOCK_FILE_LINE_PM_STATUS - 1];
 
-				if (strcmp(pmstatus, PM_STATUS_READY) == 0 ||
+				if (strcmp(pmstatus, gpdb_master_distributed_mode?PM_STATUS_DTM_RECOVERED:PM_STATUS_READY) == 0 ||
 					strcmp(pmstatus, PM_STATUS_STANDBY) == 0)
 				{
 					/* postmaster is done starting up */

--- a/src/include/utils/pidfile.h
+++ b/src/include/utils/pidfile.h
@@ -51,5 +51,6 @@
 #define PM_STATUS_STOPPING		"stopping"	/* in shutdown sequence */
 #define PM_STATUS_READY			"ready   "	/* ready for connections */
 #define PM_STATUS_STANDBY		"standby "	/* up, won't accept connections */
+#define PM_STATUS_DTM_RECOVERED "dtmready"  /* ready for distributed connections */
 
 #endif							/* UTILS_PIDFILE_H */


### PR DESCRIPTION
When starting master in distributed mode, in GPDB pg_ctl -w should
wait for distributed transaction recovery to complete. As only after
that connections are allowed.

Adding new state "dtmready" to be recorded in PID file to mark
distributed transaction recovery completion. When dtx background
worker exits successfully, postmaster writes this state to file.

pg_ctl waits for this "dtmready" state instead of "ready" state is
starting master in distribted mode which is conveyed using "-E"
postmaster options.

This patch should meet the previous expectations, that after
successfull completion of gpstart, distributed transaction can be
made.

Note:
This can't be done on master branch as depends on PostgreSQL 10 change to record PM state in PID file.