### PR TITLE
Canonicalize END INCLUSIVE value after transformation

### DIFF
--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -3988,8 +3988,8 @@ alter_table_partition_cmd:
 					pid->location  = @2;
 
 					pc->partid = pid;
-					pc->start = $4;
-					pc->end = $5;
+					pc->start = (GpPartitionRangeItem *)$4;
+					pc->end = (GpPartitionRangeItem *)$5;
 					pc->at = NULL;
 					pc->arg2 = (GpAlterPartitionCmd *)$6;
 					pc->location = @5;

--- a/src/include/parser/parse_utilcmd.h
+++ b/src/include/parser/parse_utilcmd.h
@@ -47,9 +47,7 @@ extern List *generatePartitions(Oid parentrelid, GpPartitionDefinition *gpPartSp
 								const char *queryString, List *parentoptions,
 								const char *parentaccessmethod,
 								List *parentattenc, bool forvalidationonly);
-extern void canonicalizeRangeEnd(ParseState *pstate, Const *endConst, bool endIncl,
-						   const char *part_col_name, Oid part_col_typid,
-						   int32 part_col_typmod, Oid part_col_collation);
+extern void convert_inclusive_end(Const *endConst, Oid part_col_typid, int32 part_col_typmod);
 
 typedef struct partname_comp
 {

--- a/src/test/regress/expected/partition1.out
+++ b/src/test/regress/expected/partition1.out
@@ -2487,3 +2487,281 @@ DETAIL:  UNIQUE constraint on table "t_idx_col_contain_partkey_1_prt_region1" la
 CREATE UNIQUE INDEX uidx_t_idx_col_contain_partkey on t_idx_col_contain_partkey(r_regionkey, r_name);
 DROP INDEX uidx_t_idx_col_contain_partkey;
 DROP TABLE t_idx_col_contain_partkey;
+--
+-- END INCLUSIVE should work for CREATE, ADD PARTITION, and SPLIT PARTITION for
+-- the following data types. The INCLUSIVE END value will be converted to an
+-- EXCLUSIVE upper bound during transformation. If the INCLUSIVE END value is
+-- smaller than the maximum value of the data type, the exclusive upper bound
+-- will be the END INCLUSIVE value + '1', where '1' is the resolution of the
+-- data type. Otherwise, MAXVALUE will be stored as the upper bound.
+--
+-- END INCLUSIVE should work for bigint
+CREATE TABLE end_inclusive_bigint (a int, b bigint)
+    DISTRIBUTED BY (a)
+    PARTITION BY RANGE (b)
+        (
+        PARTITION pmax_create START (9223372036854775805) END (9223372036854775807) INCLUSIVE EVERY (1),
+        PARTITION p1 START (1) END (3) INCLUSIVE,
+        PARTITION p20 START (20),
+        DEFAULT PARTITION other
+        );
+ALTER TABLE end_inclusive_bigint SPLIT DEFAULT PARTITION START (7) END (10) INCLUSIVE INTO (PARTITION p7, DEFAULT PARTITION);
+\d+ end_inclusive_bigint
+                     Partitioned table "public.end_inclusive_bigint"
+ Column |  Type   | Collation | Nullable | Default | Storage | Stats target | Description 
+--------+---------+-----------+----------+---------+---------+--------------+-------------
+ a      | integer |           |          |         | plain   |              | 
+ b      | bigint  |           |          |         | plain   |              | 
+Partition key: RANGE (b)
+Partitions: end_inclusive_bigint_1_prt_p1 FOR VALUES FROM ('1') TO ('4'),
+            end_inclusive_bigint_1_prt_p20 FOR VALUES FROM ('20') TO ('9223372036854775805'),
+            end_inclusive_bigint_1_prt_p7 FOR VALUES FROM ('7') TO ('11'),
+            end_inclusive_bigint_1_prt_pmax_create_1 FOR VALUES FROM ('9223372036854775805') TO ('9223372036854775806'),
+            end_inclusive_bigint_1_prt_pmax_create_2 FOR VALUES FROM ('9223372036854775806') TO (MAXVALUE),
+            end_inclusive_bigint_1_prt_other DEFAULT
+Distributed by: (a)
+
+ALTER TABLE end_inclusive_bigint DROP PARTITION pmax_create_1;
+ALTER TABLE end_inclusive_bigint DROP PARTITION pmax_create_2;
+ALTER TABLE end_inclusive_bigint ADD PARTITION pmax_add START (9223372036854775805) END (9223372036854775807) INCLUSIVE;
+\d+ end_inclusive_bigint
+                     Partitioned table "public.end_inclusive_bigint"
+ Column |  Type   | Collation | Nullable | Default | Storage | Stats target | Description 
+--------+---------+-----------+----------+---------+---------+--------------+-------------
+ a      | integer |           |          |         | plain   |              | 
+ b      | bigint  |           |          |         | plain   |              | 
+Partition key: RANGE (b)
+Partitions: end_inclusive_bigint_1_prt_p1 FOR VALUES FROM ('1') TO ('4'),
+            end_inclusive_bigint_1_prt_p20 FOR VALUES FROM ('20') TO ('9223372036854775805'),
+            end_inclusive_bigint_1_prt_p7 FOR VALUES FROM ('7') TO ('11'),
+            end_inclusive_bigint_1_prt_pmax_add FOR VALUES FROM ('9223372036854775805') TO (MAXVALUE),
+            end_inclusive_bigint_1_prt_other DEFAULT
+Distributed by: (a)
+
+ALTER TABLE end_inclusive_bigint DROP PARTITION pmax_add;
+ALTER TABLE end_inclusive_bigint SPLIT DEFAULT PARTITION START (9223372036854775805) END (9223372036854775807) INCLUSIVE INTO (PARTITION pmax_split, DEFAULT PARTITION);
+\d+ end_inclusive_bigint
+                     Partitioned table "public.end_inclusive_bigint"
+ Column |  Type   | Collation | Nullable | Default | Storage | Stats target | Description 
+--------+---------+-----------+----------+---------+---------+--------------+-------------
+ a      | integer |           |          |         | plain   |              | 
+ b      | bigint  |           |          |         | plain   |              | 
+Partition key: RANGE (b)
+Partitions: end_inclusive_bigint_1_prt_p1 FOR VALUES FROM ('1') TO ('4'),
+            end_inclusive_bigint_1_prt_p20 FOR VALUES FROM ('20') TO ('9223372036854775805'),
+            end_inclusive_bigint_1_prt_p7 FOR VALUES FROM ('7') TO ('11'),
+            end_inclusive_bigint_1_prt_pmax_split FOR VALUES FROM ('9223372036854775805') TO (MAXVALUE),
+            end_inclusive_bigint_1_prt_other DEFAULT
+Distributed by: (a)
+
+-- END INCLUSIVE should work for int
+CREATE TABLE end_inclusive_int (a int, b int)
+    DISTRIBUTED BY (a)
+    PARTITION BY RANGE (b)
+        (
+        PARTITION p1 END (3) INCLUSIVE,
+        PARTITION pmax END (2147483647) INCLUSIVE
+        );
+\d+ end_inclusive_int
+                       Partitioned table "public.end_inclusive_int"
+ Column |  Type   | Collation | Nullable | Default | Storage | Stats target | Description 
+--------+---------+-----------+----------+---------+---------+--------------+-------------
+ a      | integer |           |          |         | plain   |              | 
+ b      | integer |           |          |         | plain   |              | 
+Partition key: RANGE (b)
+Partitions: end_inclusive_int_1_prt_p1 FOR VALUES FROM (MINVALUE) TO (4),
+            end_inclusive_int_1_prt_pmax FOR VALUES FROM (4) TO (MAXVALUE)
+Distributed by: (a)
+
+-- END INCLUSIVE should work for smallint
+CREATE TABLE end_inclusive_smallint (a int, b smallint)
+    DISTRIBUTED BY (a)
+    PARTITION BY RANGE (b)
+        (
+        PARTITION p1 START (1) END (3) INCLUSIVE,
+        PARTITION pmax START (4) END (32767) INCLUSIVE
+        );
+\d+ end_inclusive_smallint
+                     Partitioned table "public.end_inclusive_smallint"
+ Column |   Type   | Collation | Nullable | Default | Storage | Stats target | Description 
+--------+----------+-----------+----------+---------+---------+--------------+-------------
+ a      | integer  |           |          |         | plain   |              | 
+ b      | smallint |           |          |         | plain   |              | 
+Partition key: RANGE (b)
+Partitions: end_inclusive_smallint_1_prt_p1 FOR VALUES FROM ('1') TO ('4'),
+            end_inclusive_smallint_1_prt_pmax FOR VALUES FROM ('4') TO (MAXVALUE)
+Distributed by: (a)
+
+-- END INCLUSIVE should work for date
+CREATE TABLE end_inclusive_date (a int, b date)
+    DISTRIBUTED BY (a)
+    PARTITION BY RANGE (b)
+        (
+        PARTITION p1 START ('2020-06-16') END ('2020-06-17') INCLUSIVE,
+        PARTITION pmax START ('2020-06-18') END ('infinity') INCLUSIVE
+        );
+\d+ end_inclusive_date
+                      Partitioned table "public.end_inclusive_date"
+ Column |  Type   | Collation | Nullable | Default | Storage | Stats target | Description 
+--------+---------+-----------+----------+---------+---------+--------------+-------------
+ a      | integer |           |          |         | plain   |              | 
+ b      | date    |           |          |         | plain   |              | 
+Partition key: RANGE (b)
+Partitions: end_inclusive_date_1_prt_p1 FOR VALUES FROM ('06-16-2020') TO ('06-18-2020'),
+            end_inclusive_date_1_prt_pmax FOR VALUES FROM ('06-18-2020') TO (MAXVALUE)
+Distributed by: (a)
+
+-- END INCLUSIVE should work for time without time zone
+CREATE TABLE end_inclusive_time (a int, b time)
+    DISTRIBUTED BY (a)
+    PARTITION BY RANGE (b)
+        (
+        PARTITION p1 START ('00:00:00.000001') END ('01:00:00') INCLUSIVE,
+        PARTITION pmax START ('23:00:00') END ('24:00:00') INCLUSIVE
+        );
+\d+ end_inclusive_time
+                              Partitioned table "public.end_inclusive_time"
+ Column |          Type          | Collation | Nullable | Default | Storage | Stats target | Description 
+--------+------------------------+-----------+----------+---------+---------+--------------+-------------
+ a      | integer                |           |          |         | plain   |              | 
+ b      | time without time zone |           |          |         | plain   |              | 
+Partition key: RANGE (b)
+Partitions: end_inclusive_time_1_prt_p1 FOR VALUES FROM ('00:00:00.000001') TO ('01:00:00.000001'),
+            end_inclusive_time_1_prt_pmax FOR VALUES FROM ('23:00:00') TO (MAXVALUE)
+Distributed by: (a)
+
+-- END INCLUSIVE should work for time with time zone
+CREATE TABLE end_inclusive_timetz (a int, b time with time zone)
+    DISTRIBUTED BY (a)
+    PARTITION BY RANGE (b)
+        (
+        PARTITION p1 START ('00:00:00 EST') END ('01:00:00 PST') INCLUSIVE,
+        PARTITION pmax START ('23:00:00 EST') END ('24:00:00 PST') INCLUSIVE
+        );
+\d+ end_inclusive_timetz
+                           Partitioned table "public.end_inclusive_timetz"
+ Column |        Type         | Collation | Nullable | Default | Storage | Stats target | Description 
+--------+---------------------+-----------+----------+---------+---------+--------------+-------------
+ a      | integer             |           |          |         | plain   |              | 
+ b      | time with time zone |           |          |         | plain   |              | 
+Partition key: RANGE (b)
+Partitions: end_inclusive_timetz_1_prt_p1 FOR VALUES FROM ('00:00:00-05') TO ('01:00:00.000001-08'),
+            end_inclusive_timetz_1_prt_pmax FOR VALUES FROM ('23:00:00-05') TO (MAXVALUE)
+Distributed by: (a)
+
+-- END INCLUSIVE should work for timestamp without time zone
+CREATE TABLE end_inclusive_timestamp (a int, b timestamp)
+    DISTRIBUTED BY (a)
+    PARTITION BY RANGE (b)
+        (
+        PARTITION p1 START ('2020-06-16 00:00:00') END ('2020-06-16 01:00:00') INCLUSIVE,
+        PARTITION pmax START ('2020-06-16 23:00:00') END ('infinity') INCLUSIVE
+        );
+\d+ end_inclusive_timestamp
+                              Partitioned table "public.end_inclusive_timestamp"
+ Column |            Type             | Collation | Nullable | Default | Storage | Stats target | Description 
+--------+-----------------------------+-----------+----------+---------+---------+--------------+-------------
+ a      | integer                     |           |          |         | plain   |              | 
+ b      | timestamp without time zone |           |          |         | plain   |              | 
+Partition key: RANGE (b)
+Partitions: end_inclusive_timestamp_1_prt_p1 FOR VALUES FROM ('Tue Jun 16 00:00:00 2020') TO ('Tue Jun 16 01:00:00.000001 2020'),
+            end_inclusive_timestamp_1_prt_pmax FOR VALUES FROM ('Tue Jun 16 23:00:00 2020') TO (MAXVALUE)
+Distributed by: (a)
+
+-- END INCLUSIVE should work for timestamp with time zone
+CREATE TABLE end_inclusive_timestamptz (a int, b timestamp with time zone)
+    DISTRIBUTED BY (a)
+    PARTITION BY RANGE (b)
+        (
+        PARTITION p1 START ('2020-06-16 00:00:00 PST') END ('2020-06-16 01:00:00 PST') INCLUSIVE,
+        PARTITION pmax START ('2020-06-16 23:00:00 EST') END ('infinity') INCLUSIVE
+        );
+\d+ end_inclusive_timestamptz
+                           Partitioned table "public.end_inclusive_timestamptz"
+ Column |           Type           | Collation | Nullable | Default | Storage | Stats target | Description 
+--------+--------------------------+-----------+----------+---------+---------+--------------+-------------
+ a      | integer                  |           |          |         | plain   |              | 
+ b      | timestamp with time zone |           |          |         | plain   |              | 
+Partition key: RANGE (b)
+Partitions: end_inclusive_timestamptz_1_prt_p1 FOR VALUES FROM ('Tue Jun 16 01:00:00 2020 PDT') TO ('Tue Jun 16 02:00:00.000001 2020 PDT'),
+            end_inclusive_timestamptz_1_prt_pmax FOR VALUES FROM ('Tue Jun 16 21:00:00 2020 PDT') TO (MAXVALUE)
+Distributed by: (a)
+
+-- END INCLUSIVE should work for interval
+CREATE TABLE end_inclusive_interval (a int, b interval)
+    DISTRIBUTED BY (a)
+    PARTITION BY RANGE (b)
+        (
+        PARTITION p1 START ('1 year') END ('2 years') INCLUSIVE
+        );
+\d+ end_inclusive_interval
+                     Partitioned table "public.end_inclusive_interval"
+ Column |   Type   | Collation | Nullable | Default | Storage | Stats target | Description 
+--------+----------+-----------+----------+---------+---------+--------------+-------------
+ a      | integer  |           |          |         | plain   |              | 
+ b      | interval |           |          |         | plain   |              | 
+Partition key: RANGE (b)
+Partitions: end_inclusive_interval_1_prt_p1 FOR VALUES FROM ('@ 1 year') TO ('@ 2 years 0.000001 secs')
+Distributed by: (a)
+
+-- END INCLUSIVE with MAXVALUE should work with implicit START/END
+DROP TABLE end_inclusive_int;
+CREATE TABLE end_inclusive_int (a int, b int)
+    DISTRIBUTED BY (a)
+    PARTITION BY RANGE (b)
+        (
+        PARTITION p1 START (1),
+        PARTITION pmax END (2147483647) INCLUSIVE,
+        PARTITION p2 START (2) END (5) INCLUSIVE
+        );
+\d+ end_inclusive_int
+                       Partitioned table "public.end_inclusive_int"
+ Column |  Type   | Collation | Nullable | Default | Storage | Stats target | Description 
+--------+---------+-----------+----------+---------+---------+--------------+-------------
+ a      | integer |           |          |         | plain   |              | 
+ b      | integer |           |          |         | plain   |              | 
+Partition key: RANGE (b)
+Partitions: end_inclusive_int_1_prt_p1 FOR VALUES FROM (1) TO (2),
+            end_inclusive_int_1_prt_p2 FOR VALUES FROM (2) TO (6),
+            end_inclusive_int_1_prt_pmax FOR VALUES FROM (6) TO (MAXVALUE)
+Distributed by: (a)
+
+DROP TABLE end_inclusive_int;
+CREATE TABLE end_inclusive_int (a int, b int)
+    DISTRIBUTED BY (a)
+    PARTITION BY RANGE (b)
+        (
+        PARTITION pmax END (2147483647) INCLUSIVE,
+        PARTITION p1 START (1),
+        PARTITION p2 START (2) END (5) INCLUSIVE
+        );
+\d+ end_inclusive_int
+                       Partitioned table "public.end_inclusive_int"
+ Column |  Type   | Collation | Nullable | Default | Storage | Stats target | Description 
+--------+---------+-----------+----------+---------+---------+--------------+-------------
+ a      | integer |           |          |         | plain   |              | 
+ b      | integer |           |          |         | plain   |              | 
+Partition key: RANGE (b)
+Partitions: end_inclusive_int_1_prt_p1 FOR VALUES FROM (1) TO (2),
+            end_inclusive_int_1_prt_p2 FOR VALUES FROM (2) TO (6),
+            end_inclusive_int_1_prt_pmax FOR VALUES FROM (6) TO (MAXVALUE)
+Distributed by: (a)
+
+-- END INCLUSIVE should fail when precision is specified
+CREATE TABLE end_inclusive_time_with_precision (a int, b time(5))
+    DISTRIBUTED BY (a)
+    PARTITION BY RANGE (b)
+        (
+        PARTITION p1 START ('00:00:00') END ('01:00:00') INCLUSIVE
+        );
+ERROR:  END INCLUSIVE not supported when partition key has precision specification: time(5) without time zone
+HINT:  Specify an exclusive END value and remove the INCLUSIVE keyword
+-- END INCLUSIVE should fail for unsupported data types
+CREATE TABLE end_inclusive_numeric (a int, b numeric)
+    DISTRIBUTED BY (a)
+    PARTITION BY RANGE (b)
+        (
+        PARTITION p1 START (1) END (3) INCLUSIVE
+        );
+ERROR:  END INCLUSIVE not supported for partition key data type: numeric
+HINT:  Specify an exclusive END value and remove the INCLUSIVE keyword


### PR DESCRIPTION
Commit b23036066df7d4851855402c0dbed245c1e63f3b added initial support
for INCLUSIVE END for Integer and Date data types by constructing a "+1"
expression node and evaluate that. This patch instead directly operates
"+1" on the already transformed endConst->constvalue, which is more
straightforward and error pruning.

Still, we only support limited data types. We support any data types
that can be coerced into the following types:

int8, date, interval, timestamp, timestamp with time zone

Now that we are not constructing the "+1" expression state for END
INCLUSIVE anymore as we do for EVERY, they no longer share the same
code, hence reverted the refactor code for that in commit
b23036066df7d4851855402c0dbed245c1e63f3b.