### PR TITLE
Remove Blowfish in pgcrypto fips test.

### DIFF
--- a/contrib/pgcrypto/expected/fips_1.out
+++ b/contrib/pgcrypto/expected/fips_1.out
@@ -116,16 +116,4 @@ SELECT encrypt('santa claus', 'mypass', 'aes') as raw_aes;
  \xe7ac3ad57bde59c5b78c08805afdb774
 (1 row)
 
-SELECT 'Test raw encrypt : EXPECTED FAIL FIPS' as comment;
-                comment                
----------------------------------------
- Test raw encrypt : EXPECTED FAIL FIPS
-(1 row)
-
-SELECT encrypt('santa claus', 'mypass', 'bf') as raw_blowfish;
-            raw_blowfish            
-------------------------------------
- \x0f4fe496594a2e762fb29a22fc6750e2
-(1 row)
-
 DROP TABLE fipstest;

--- a/contrib/pgcrypto/expected/fips_2.out
+++ b/contrib/pgcrypto/expected/fips_2.out
@@ -96,6 +96,4 @@ SELECT 'Test raw encrypt : EXPECTED FAIL FIPS' as comment;
  Test raw encrypt : EXPECTED FAIL FIPS
 (1 row)
 
-SELECT encrypt('santa claus', 'mypass', 'bf') as raw_blowfish;
-ERROR:  requested functionality not allowed in FIPS mode (openssl.c:772)
 DROP TABLE fipstest;

--- a/contrib/pgcrypto/sql/fips.sql
+++ b/contrib/pgcrypto/sql/fips.sql
@@ -34,7 +34,4 @@ select pgp_sym_decrypt(pgp_sym_encrypt('santa clause', 'mypass', 'cipher-algo=bf
 SELECT 'Test raw encrypt : EXPECTED PASS' as comment;
 SELECT encrypt('santa claus', 'mypass', 'aes') as raw_aes;
 
-SELECT 'Test raw encrypt : EXPECTED FAIL FIPS' as comment;
-SELECT encrypt('santa claus', 'mypass', 'bf') as raw_blowfish;
-
 DROP TABLE fipstest;


### PR DESCRIPTION
OpenSSL 3.0 move Blowfish to the legacy provider. the user need to modify openssl.cnf to load the legacy provider.

since Blowfish already tested in sql/blowfish.sql, remove this test in sql/fips.sql

same as 7b6ce36fbab