### PR TITLE
Disable test predicate-lock-hot-tuple, update-conflict-out

### DIFF
--- a/src/test/isolation/isolation_schedule
+++ b/src/test/isolation/isolation_schedule
@@ -44,6 +44,9 @@
 # don't pass in normal mode for GPDB as SELECT..FOR SHARE/UPDATE can
 # block each other in gpdb if GDD does not open.
 #
+# GPDB_12_MERGE_FRATURE_NOT_SUPPORTED: disable test predicate-lock-hot-tuple, update-conflict-out
+# because Greenplum does not support serializable transactions.
+#
 #############################################################
 #
 # IMPORTANT: Isolation tests are run with gp_role=utility
@@ -70,8 +73,6 @@ test: read-only-anomaly
 #test: two-ids
 #test: multiple-row-versions
 #test: index-only-scan
-test: predicate-lock-hot-tuple
-test: update-conflict-out
 test: deadlock-simple
 test: deadlock-hard
 test: deadlock-soft


### PR DESCRIPTION
Disable test predicate-lock-hot-tuple, update-conflict-out because 
Greenplum does not support serializable transactions.