### PR TITLE
fix create index does not pass permission check for schema on QE, if the owner of s.t is not current user

### DIFF
--- a/contrib/citext/expected/create_index_acl.out
+++ b/contrib/citext/expected/create_index_acl.out
@@ -88,3 +88,17 @@ ALTER TABLE s.x ADD CONSTRAINT underqualified EXCLUDE USING btree
 ERROR:  42704
 \set VERBOSITY default
 ROLLBACK;
+-- before dispatch stmt to QEs, switching user to login user,
+-- so that the connection to QEs use the same user as the connection to QD.
+-- pass the permission check of schema on QEs.
+CREATE ROLE regress_minimal;
+NOTICE:  resource queue required -- using default resource queue "pg_default"
+CREATE SCHEMA s;
+create table s.t(tc1 int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'tc1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+alter table s.t owner to regress_minimal;
+create index idx on s.t(tc1);
+drop schema s cascade;
+NOTICE:  drop cascades to table s.t
+drop role regress_minimal;

--- a/contrib/citext/sql/create_index_acl.sql
+++ b/contrib/citext/sql/create_index_acl.sql
@@ -92,3 +92,14 @@ ALTER TABLE s.x ADD CONSTRAINT underqualified EXCLUDE USING btree
   WHERE (s.index_row_if(y));
 \set VERBOSITY default
 ROLLBACK;
+
+-- before dispatch stmt to QEs, switching user to login user,
+-- so that the connection to QEs use the same user as the connection to QD.
+-- pass the permission check of schema on QEs.
+CREATE ROLE regress_minimal;
+CREATE SCHEMA s;
+create table s.t(tc1 int);
+alter table s.t owner to regress_minimal;
+create index idx on s.t(tc1);
+drop schema s cascade;
+drop role regress_minimal;

--- a/src/backend/commands/indexcmds.c
+++ b/src/backend/commands/indexcmds.c
@@ -1654,18 +1654,26 @@ DefineIndex(Oid relationId,
 		stmt->idxname = indexRelationName;
 		if (shouldDispatch)
 		{
+			Oid			save_userid;
+			int			save_sec_context;
 			/* make sure the QE uses the same index name that we chose */
 			stmt->oldNode = InvalidOid;
 			Assert(stmt->relation != NULL);
 
 			stmt->tableSpace = get_tablespace_name(tablespaceId);
-
+			/*
+			 * Switch to login user, so that the connection to QEs use the
+			 * same user as the connection to QD.
+			 */
+			GetUserIdAndSecContext(&save_userid, &save_sec_context);
+			SetUserIdAndSecContext(root_save_userid, root_save_sec_context);
 			CdbDispatchUtilityStatement((Node *) stmt,
 										DF_CANCEL_ON_ERROR |
 										DF_WITH_SNAPSHOT |
 										DF_NEED_TWO_PHASE,
 										GetAssignedOidsForDispatch(),
 										NULL);
+			SetUserIdAndSecContext(save_userid, save_sec_context);
 		}
 
 		/*
@@ -1683,15 +1691,24 @@ DefineIndex(Oid relationId,
 	stmt->idxname = indexRelationName;
 	if (shouldDispatch)
 	{
+		Oid			save_userid;
+		int			save_sec_context;
 		/* make sure the QE uses the same index name that we chose */
 		stmt->oldNode = InvalidOid;
 		Assert(stmt->relation != NULL);
+		/*
+		 * Switch to login user, so that the connection to QEs use the
+		 * same user as the connection to QD.
+		 */
+		GetUserIdAndSecContext(&save_userid, &save_sec_context);
+		SetUserIdAndSecContext(root_save_userid, root_save_sec_context);
 		CdbDispatchUtilityStatement((Node *) stmt,
 									DF_CANCEL_ON_ERROR |
 									DF_WITH_SNAPSHOT |
 									DF_NEED_TWO_PHASE,
 									GetAssignedOidsForDispatch(),
 									NULL);
+		SetUserIdAndSecContext(save_userid, save_sec_context);
 
 		/* Set indcheckxmin in the master, if it was set on any segment */
 		if (!indexInfo->ii_BrokenHotChain)


### PR DESCRIPTION
The following SQL hits the error "permission denied for schema s" on QE.
CREATE ROLE regress_minimal;
CREATE SCHEMA s;
create table s.t(tc1 int);
alter table s.t owner to regress_minimal;
create index idx on s.t(tc1);

The owner of s is login user, but the owner of s.t is regress_minimal,
when we create index for s.t, we will switch CurrentUserId to regress_minimal,
and we use regress_minimal to establish connection with QE,
regress_minimal does not have the permission of s. 
so check permission failed.

before dispatch stmt to QEs, switching user to login user,
so that the connection to QEs use the same user as the connection to QD.
pass the permission check of schema on QEs.

The above case is ok on main branch, however, failed on 6x_stable branch,
because this is introduced by the commit: [09fde60203d78dc06c16d433a65673919a641fdd](https://github.com/greenplum-db/gpdb/commit/09fde60203d78dc06c16d433a65673919a641fdd) on 6x_stable.
which is corresponding to the commit: 7f098f7b53 on PostgreSQL.

the postgreSQL-merge branch rel_12_12 failed as 6x_stable does after we merge
commit:7f098f7b53 on PostgreSQL