### PR TITLE
Fix alter table regression case.

### DIFF
--- a/src/backend/access/common/reloptions.c
+++ b/src/backend/access/common/reloptions.c
@@ -670,13 +670,6 @@ allocate_reloption(bits32 kinds, int type, const char *name, const char *desc,
 	newoption->type = type;
 	newoption->lockmode = lockmode;
 
-	/*
-	 * Set the default lock mode for this option.  There is no actual way
-	 * for a module to enforce it when declaring a custom relation option,
-	 * so just use the highest level, which is safe for all cases.
-	 */
-	newoption->lockmode = AccessExclusiveLock;
-
 	MemoryContextSwitchTo(oldcxt);
 
 	return newoption;
@@ -723,9 +716,8 @@ add_int_reloption(bits32 kinds, const char *name, const char *desc, int default_
  *		Add a new float reloption
  */
 void
-add_real_reloption(bits32 kinds, const char *name, const char *desc,
-				   double default_val, double min_val, double max_val,
-				   LOCKMODE lockmode)
+add_real_reloption(bits32 kinds, const char *name, const char *desc, double default_val,
+				   double min_val, double max_val, LOCKMODE lockmode)
 {
 	relopt_real *newoption;
 
@@ -748,9 +740,8 @@ add_real_reloption(bits32 kinds, const char *name, const char *desc,
  * the validation.
  */
 void
-add_string_reloption(bits32 kinds, const char *name, const char *desc,
-					 const char *default_val, validate_string_relopt validator,
-					 LOCKMODE lockmode)
+add_string_reloption(bits32 kinds, const char *name, const char *desc, const char *default_val,
+					 validate_string_relopt validator, LOCKMODE lockmode)
 {
 	relopt_string *newoption;
 

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -3943,9 +3943,9 @@ RenameRelation(RenameStmt *stmt)
 	 * escalation.  However, because ALTER INDEX can be used with any relation
 	 * type, we mustn't believe without verification.
 	 */
+	LOCKMODE	lockmode;
 	for (;;)
 	{
-		LOCKMODE	lockmode;
 		char		relkind;
 		bool		obj_is_index;
 
@@ -3984,7 +3984,7 @@ RenameRelation(RenameStmt *stmt)
 	 * Grab an exclusive lock on the target table, index, sequence
 	 * or view, which we will NOT release until end of transaction.
 	 */
-	targetrelation = relation_open(relid, AccessExclusiveLock);
+	targetrelation = relation_open(relid, lockmode);
 	oldrelname = pstrdup(RelationGetRelationName(targetrelation));
 
 	/* Do the work */

--- a/src/include/access/reloptions.h
+++ b/src/include/access/reloptions.h
@@ -276,7 +276,7 @@ extern void add_int_reloption(bits32 kinds, const char *name, const char *desc,
 							  int default_val, int min_val, int max_val,
 							  LOCKMODE lockmode);
 extern void add_real_reloption(bits32 kinds, const char *name, const char *desc,
-							   double default_val, double min_val,double max_val,
+							   double default_val, double min_val, double max_val,
 							   LOCKMODE lockmode);
 extern void add_string_reloption(bits32 kinds, const char *name, const char *desc,
 								 const char *default_val, validate_string_relopt validator,

--- a/src/test/regress/expected/alter_table.out
+++ b/src/test/regress/expected/alter_table.out
@@ -1081,6 +1081,8 @@ drop table atacc1;
 create table atacc1 (a int primary key);
 alter table atacc1 add constraint atacc1_fkey foreign key (a) references atacc1 (a) not valid;
 alter table atacc1 validate constraint atacc1_fkey, alter a type bigint;
+ERROR:  cannot alter column with primary key or unique constraint
+HINT:  DROP the constraint first, and recreate it after the ALTER
 drop table atacc1;
 -- we've also seen issues with check constraints being validated at the wrong
 -- time when there's a pending table rewrite.
@@ -4465,8 +4467,8 @@ create trigger xtrig
   after update on bar1
   referencing old table as old
   for each statement execute procedure xtrig();
+ERROR:  Triggers for statements are not yet supported
 update bar1 set a = a + 1;
-INFO:  a=1, b=1
 /* End test case for bug #16242 */
 -- Test that ALTER TABLE rewrite preserves a clustered index
 -- for normal indexes and indexes on constraints.
@@ -4485,6 +4487,8 @@ select indexrelid::regclass, indisclustered from pg_index
 (2 rows)
 
 alter table alttype_cluster alter a type bigint;
+ERROR:  cannot alter column with primary key or unique constraint
+HINT:  DROP the constraint first, and recreate it after the ALTER
 select indexrelid::regclass, indisclustered from pg_index
   where indrelid = 'alttype_cluster'::regclass
   order by indexrelid::regclass::text;
@@ -4506,6 +4510,8 @@ select indexrelid::regclass, indisclustered from pg_index
 (2 rows)
 
 alter table alttype_cluster alter a type int;
+ERROR:  cannot alter column with primary key or unique constraint
+HINT:  DROP the constraint first, and recreate it after the ALTER
 select indexrelid::regclass, indisclustered from pg_index
   where indrelid = 'alttype_cluster'::regclass
   order by indexrelid::regclass::text;

--- a/src/test/regress/init_file
+++ b/src/test/regress/init_file
@@ -163,6 +163,10 @@ s/\(dbsize\.c:\d+\)/\(dbsize\.c:XXX\)/
 m/ \(cdbdisp_async\.c.*\)/
 s/ \(cdbdisp_async\.c.*\)//
 
+# remove the parse_utilcmd suffix of some ERROR messages
+m/ \(parse_utilcmd\.c\:\d+\)/
+s/ \(parse_utilcmd\.c:\d+\)//
+
 # ignore establish time and segindex num
 m/ The shortest establish conn time: \d+\.\d+ ms, segindex: \d+,/
 s/ The shortest establish conn time: \d+\.\d+ ms, segindex: \d+,/ The shortest establish conn time: xx\.xx ms, segindex: xx,/


### PR DESCRIPTION
- Feature not supported: 

Currently, GPDB doesn't support alter type on primary key and unique
constraint column. Because it requires drop - recreate logic.
The drop currently only performs on master which lead error when
recreating index (since recreate index will dispatch to segments and
there still old constraint index exists)

- Fix lockmode misuse in `RenameRelation`:

In `RenameRelation`:
https://github.com/greenplum-db/gpdb-postgres-merge/blob/ff4f020c6761a8ee1b5e79d259b401ed0a55c5b2/src/backend/commands/tablecmds.c#L4000

It used `AccessExclusiveLock` unconditionally to open the target relation, but for index statement, it should use `ShareUpdateExclusiveLock`:

https://github.com/greenplum-db/gpdb-postgres-merge/blob/ff4f020c6761a8ee1b5e79d259b401ed0a55c5b2/src/backend/commands/tablecmds.c#L3957

Before this fix, there was a diff in the test case:
```
diff -I HINT: -I CONTEXT: -I GP_IGNORE: -U3 /home/gpadmin/gpdb-postgres-merge/src/test/regress/expected/alter_table.out /home/gpadmin/gpdb-postgres-merge/src/test/regress/results/alter_table.out
--- /home/gpadmin/gpdb-postgres-merge/src/test/regress/expected/alter_table.out 2022-12-14 13:17:22.965202903 +0800
+++ /home/gpadmin/gpdb-postgres-merge/src/test/regress/results/alter_table.out  2022-12-14 13:17:23.089203851 +0800
@@ -260,9 +260,11 @@
 ORDER BY relation::regclass::text COLLATE "C";
               relation              |           mode
 ------------------------------------+--------------------------
+ alter_idx_rename_test_idx_2        | AccessExclusiveLock
  alter_idx_rename_test_idx_2        | ShareUpdateExclusiveLock
+ alter_idx_rename_test_parted_idx_2 | AccessExclusiveLock
  alter_idx_rename_test_parted_idx_2 | ShareUpdateExclusiveLock
-(2 rows)
+(4 rows) COMMIT;
 BEGIN;
```

- Different behaviours in `AlterTableGetLockLevel / AlterTableGetRelOptionsLockLevel`:

In case `AT_ResetRelOptions`, the lock mode is determined in `AlterTableGetRelOptionsLockLevel()`, Setting multiple options together uses the highest lock level required for any option. And in GPDB, the highest lockmode is set by this relOption:

But `allocate_reloption()` hard-coded the lockmode as `AccessExclusiveLock`:
https://github.com/greenplum-db/gpdb-postgres-merge/blob/e1e395db886cdfc0fd19c89aa4f27cdbdc09cd28/src/backend/access/common/reloptions.c#L678

This can be resolved by backporting an upstream commit: https://github.com/postgres/postgres/commit/69f94108079d70093b59096a3ae0ad82c842b4c0