### PR TITLE
Avoid calling RelationInitTableAccessMethod() for partition roots

### DIFF
--- a/src/backend/utils/cache/relcache.c
+++ b/src/backend/utils/cache/relcache.c
@@ -1268,7 +1268,6 @@ retry:
 		case RELKIND_RELATION:
 		case RELKIND_TOASTVALUE:
 		case RELKIND_MATVIEW:
-		case RELKIND_PARTITIONED_TABLE:
 			Assert(relation->rd_rel->relam != InvalidOid);
 			RelationInitTableAccessMethod(relation);
 			break;
@@ -1286,6 +1285,9 @@ retry:
 		case RELKIND_AOBLOCKDIR:
 			Assert(relation->rd_rel->relam != InvalidOid);
 			RelationInitTableAccessMethod(relation);
+			break;
+		case RELKIND_PARTITIONED_TABLE:
+			Assert(relation->rd_rel->relam != InvalidOid);
 			break;
 	}
 


### PR DESCRIPTION
The call was originally intended to ensure the AM can be passed down to partition leaves from the root. RelationInitTableAccessMethod() ensured that the table AM handler was set and decisions based on that were taken in other pieces of code.

However, we no longer rely on the table AM handler, but the relam property instead, which is not touched by this routine. Thus, this call is superfluous.

It also breaks the following test case in update.sql:
``` 
@@ -894,7 +891,11 @@ insert into utrtest values (2, 'bar')
   returning *, tableoid::regclass, cmin;  -- fails
-ERROR:  cannot retrieve a system column in this context
+ a |  b  | tableoid | cmin +---+-----+----------+------
+ 2 | bar | utr2     |    0
+(1 row)
+
```
So, remove it.

Co-authored-by: Soumyadeep Chakraborty <soumyadeep2007@gmail.com>